### PR TITLE
Optionally allow extra keys in check-model-has-meta-keys

### DIFF
--- a/HOOKS.md
+++ b/HOOKS.md
@@ -280,10 +280,13 @@ If you `run` your model and then you delete the description from a properties fi
 
 Ensures that the model has a list of valid meta keys. (usually `schema.yml`).
 
+By default, it does not allow the model to have any other meta keys other than the ones required. An optional argument can be used to allow for extra keys.
+
 #### Arguments
 
 `--manifest`: location of `manifest.json` file. Usually `target/manifest.json`. This file contains a full representation of dbt project. **Default: `target/manifest.json`**<br/>
-`--meta-keys`: list of the required keys in the meta part of the model.
+`--meta-keys`: list of the required keys in the meta part of the model.<br/>
+`--allow-extra-keys`: whether extra keys are allowed. **Default: `False`**.
 
 #### Example
 ```

--- a/tests/unit/test_check_model_has_meta_keys.py
+++ b/tests/unit/test_check_model_has_meta_keys.py
@@ -5,6 +5,9 @@ from pre_commit_dbt.check_model_has_meta_keys import main
 # Input args, valid manifest, expected return value
 TESTS = (
     (["aa/bb/with_meta.sql", "--meta-keys", "foo", "bar"], True, 0),
+    (["aa/bb/with_meta.sql", "--meta-keys", "foo", "--allow-extra-keys"], True, 0),
+    (["aa/bb/with_meta.sql", "--meta-keys", "xyz", "--allow-extra-keys"], True, 1),
+    (["aa/bb/with_meta.sql", "--meta-keys", "foo"], True, 1),
     (["aa/bb/with_meta.sql", "--meta-keys", "foo", "bar"], False, 1),
     (["aa/bb/without_meta.sql", "--meta-keys", "foo", "bar"], True, 1),
 )


### PR DESCRIPTION
Today `check-model-has-meta-keys` does not allow the model to have any other meta keys other than the ones required. 

This PR introduces an optional argument to allow for it.
Our use case is that we need a check that checks that all models have, at a minimum, an "owner" meta key, while still allowing other meta keys (PII, etc).

The extra parameter has a `False` default value, meaning it is backward compatible with everyone that is using the check today.

More context on: https://github.com/offbi/pre-commit-dbt/issues/60