### PR TITLE
Make check_column_name_contract case insensitive for pattern and datatype

### DIFF
--- a/dbt_checkpoint/check_column_name_contract.py
+++ b/dbt_checkpoint/check_column_name_contract.py
@@ -43,7 +43,7 @@ def check_column_name_contract(
 
             # Check all files of type dtype follow naming pattern
             if dtype.lower() == col_type.lower():
-                if re.match(pattern, col_name) is None:
+                if re.match(pattern, col_name, re.IGNORECASE) is None:
                     status_code = 1
                     print(
                         f"{red(col_name)}: column is of type {yellow(dtype)} and "

--- a/dbt_checkpoint/check_column_name_contract.py
+++ b/dbt_checkpoint/check_column_name_contract.py
@@ -42,7 +42,7 @@ def check_column_name_contract(
             col_type = col.get("type")
 
             # Check all files of type dtype follow naming pattern
-            if dtype == col_type:
+            if dtype.lower() == col_type.lower():
                 if re.match(pattern, col_name) is None:
                     status_code = 1
                     print(

--- a/dbt_checkpoint/check_column_name_contract.py
+++ b/dbt_checkpoint/check_column_name_contract.py
@@ -51,7 +51,7 @@ def check_column_name_contract(
                     )
 
             # Check all files with naming pattern are of type dtype
-            elif re.match(pattern, col_name):
+            elif re.match(pattern, col_name, re.IGNORECASE):
                 status_code = 1
                 print(
                     f"{red(col_name)}: name matches regex pattern {yellow(pattern)} "

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -377,7 +377,7 @@ CATALOG = {
             "columns": {
                 "is_boolean": {"type": "boolean", "name": "is_boolean"},
                 "COL2": {"type": "TEXT", "name": "COL2"},
-                "is_also_boolean": {"type": "BOOLEAN", "name": "is_also_boolean"},
+                "IS_ALSO_BOOLEAN": {"type": "BOOLEAN", "name": "IS_ALSO_BOOLEAN"},
             },
         },
         "model.test.with_boolean_column_without_prefix": {

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -383,7 +383,8 @@ CATALOG = {
             "metadata": {},
             "columns": {
                 "COL1": {"type": "boolean", "name": "COL1"},
-                "COL2": {"type": "TEXT", "name": "COL2"},
+                "COL2": {"type": "BOOLEAN", "name": "COL2"},
+                "COL3": {"type": "TEXT", "name": "COL3"},
             },
         },
         "model.test.without_boolean_column_with_prefix": {

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -377,6 +377,7 @@ CATALOG = {
             "columns": {
                 "is_boolean": {"type": "boolean", "name": "is_boolean"},
                 "COL2": {"type": "TEXT", "name": "COL2"},
+                "is_also_boolean": {"type": "BOOLEAN", "name": "is_also_boolean"},
             },
         },
         "model.test.with_boolean_column_without_prefix": {


### PR DESCRIPTION
Make check_column_name_contract case insensitive for pattern and datatype. We use Snowflake and were finding that the check_column_name_contract hook wasn't working as expected with the following args:

`[--pattern, "(is|has)_.*", --dtype, boolean]`

What was happening was that the catalog.json file was uppercasing the column names and datatypes, so when dbt-checkpoint was comparing the catalog to the config, nothing was being caught. There are workarounds by adding additional hooks and using more extensive regexes, but this caused a headache and it seems like dbt-checkpoint should be able to handle this. 
