### PR TITLE
doc: describe a faster build configuration in the example

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,7 +161,6 @@ repos:
   hooks:
   - id: check-script-semicolon
   - id: check-script-has-no-table-name
-  - id: dbt-test
   - id: dbt-parse
   - id: dbt-docs-generate
     args: ["--cmd-flags", "++no-compile"]

--- a/README.md
+++ b/README.md
@@ -162,7 +162,9 @@ repos:
   - id: check-script-semicolon
   - id: check-script-has-no-table-name
   - id: dbt-test
+  - id: dbt-parse
   - id: dbt-docs-generate
+    args: ["--cmd-flags", "++no-compile"]
   - id: check-model-has-all-columns
     name: Check columns - core
     files: ^models/core


### PR DESCRIPTION
This is addressing https://github.com/dbt-checkpoint/dbt-checkpoint/issues/205

It's only about documenting in Readme.md in the Setup example the fastest way to execute the checks.

I replaced `dbt-test` with `dbt-deps` command as I think usually you'd like to run tests separately and for the typical dbt-checkpoint use cases the `dbt-deps` is more suited.