### PR TITLE
Feature: Add check-source-has-description hook

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -169,6 +169,12 @@
   entry: check-source-has-all-columns
   language: python
   types_or: [yaml]
+- id: check-source-has-description
+  name: Check the source has description
+  description: Ensures that the source has description.
+  entry: check-source-has-description
+  language: python
+  types_or: [yaml]
 - id: check-source-table-has-description
   name: Check the source table has description
   description: Ensures that the source table has description in properties file.

--- a/HOOKS.md
+++ b/HOOKS.md
@@ -38,6 +38,7 @@
 
 - [`check-source-columns-have-desc`](https://github.com/dbt-checkpoint/dbt-checkpoint/blob/main/HOOKS.md#check-source-columns-have-desc): Check for source column descriptions.
 - [`check-source-has-all-columns`](https://github.com/dbt-checkpoint/dbt-checkpoint/blob/main/HOOKS.md#check-source-has-all-columns): Check the source has all columns in the properties file.
+- [`check-source-has-description`](https://github.com/dbt-checkpoint/dbt-checkpoint/blob/main/HOOKS.md#check-source-has-description): Check the source has description.
 - [`check-source-table-has-description`](https://github.com/dbt-checkpoint/dbt-checkpoint/blob/main/HOOKS.md#check-source-table-has-description): Check the source table has description.
 - [`check-source-has-freshness`](https://github.com/dbt-checkpoint/dbt-checkpoint/blob/main/HOOKS.md#check-source-has-freshness): Check the source has the freshness.
 - [`check-source-has-loader`](https://github.com/dbt-checkpoint/dbt-checkpoint/blob/main/HOOKS.md#check-source-has-loader): Check the source has loader option.
@@ -1249,6 +1250,41 @@ You want to make sure that you have all the database columns listed in the prope
 #### Known limitations
 
 If you did not update the catalog and manifest results can be wrong.
+
+---
+
+### `check-source-has-description`
+
+Ensures that the source has a description in the properties file (usually `schema.yml`).
+
+#### Example
+
+```
+repos:
+- repo: https://github.com/dbt-checkpoint/dbt-checkpoint
+ rev: v1.0.0
+ hooks:
+ - id: check-source-has-description
+```
+
+#### When to use it
+
+You want to make sure that all sources have a description.
+
+#### Requirements
+
+| Model exists in `manifest.json` <sup id="a1">[1](#f1)</sup> | Model exists in `catalog.json` <sup id="a2">[2](#f2)</sup> |
+| :---------------------------------------------------------: | :--------------------------------------------------------: |
+|                       :x: Not needed                        |                       :x: Not needed                       |
+
+<sup id="f1">1</sup> It means that you need to run `dbt parse` before run this hook (dbt >= 1.5).<br/>
+<sup id="f2">2</sup> It means that you need to run `dbt docs generate` before run this hook.
+
+#### How it works
+
+- Hook takes all changed `yml`.
+- All sources from yml file are parsed.
+- If the source does not have a description set, the hook fails.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -107,6 +107,7 @@ Since the root-level `exclude` statement is handled by pre-commit, when those ho
 
 - [`check-source-columns-have-desc`](https://github.com/dbt-checkpoint/dbt-checkpoint/blob/main/HOOKS.md#check-source-columns-have-desc): Check for source column descriptions.
 - [`check-source-has-all-columns`](https://github.com/dbt-checkpoint/dbt-checkpoint/blob/main/HOOKS.md#check-source-has-all-columns): Check the source has all columns in the properties file.
+- [`check-source-has-description`](https://github.com/dbt-checkpoint/dbt-checkpoint/blob/main/HOOKS.md#check-source-has-description): Check the source has description.
 - [`check-source-table-has-description`](https://github.com/dbt-checkpoint/dbt-checkpoint/blob/main/HOOKS.md#check-source-table-has-description): Check the source table has description.
 - [`check-source-has-freshness`](https://github.com/dbt-checkpoint/dbt-checkpoint/blob/main/HOOKS.md#check-source-has-freshness): Check the source has the freshness.
 - [`check-source-has-loader`](https://github.com/dbt-checkpoint/dbt-checkpoint/blob/main/HOOKS.md#check-source-has-loader): Check the source has loader option.

--- a/dbt_checkpoint/check_source_has_description.py
+++ b/dbt_checkpoint/check_source_has_description.py
@@ -1,0 +1,69 @@
+import argparse
+import os
+import time
+from pathlib import Path
+from typing import Any, Dict, Optional, Sequence
+
+from dbt_checkpoint.tracking import dbtCheckpointTracking
+from dbt_checkpoint.utils import (
+    JsonOpenError,
+    add_default_args,
+    get_dbt_manifest,
+    get_source_schemas,
+    red,
+)
+
+
+def has_description(paths: Sequence[str], include_disabled: bool = False) -> Dict[str, Any]:
+    status_code = 0
+    ymls = [Path(path) for path in paths]
+
+    # if user added schema but did not rerun
+    schemas = get_source_schemas(ymls, include_disabled=include_disabled)
+
+    for schema in schemas:
+        if not schema.source_schema.get("description"):
+            status_code = 1
+            print(
+                f'{red(f"{schema.source_name}.{schema.table_name}")}: '
+                f"does not have defined description.",
+            )
+    return {"status_code": status_code}
+
+
+def main(argv: Optional[Sequence[str]] = None) -> int:
+    parser = argparse.ArgumentParser()
+    add_default_args(parser)
+
+    args = parser.parse_args(argv)
+
+    try:
+        manifest = get_dbt_manifest(args)
+    except JsonOpenError as e:
+        print(f"Unable to load manifest file ({e})")
+        return 1
+
+    start_time = time.time()
+    hook_properties = has_description(
+        paths=args.filenames, include_disabled=args.include_disabled
+    )
+    end_time = time.time()
+    script_args = vars(args)
+
+    tracker = dbtCheckpointTracking(script_args=script_args)
+    tracker.track_hook_event(
+        event_name="Hook Executed",
+        manifest=manifest,
+        event_properties={
+            "hook_name": os.path.basename(__file__),
+            "description": "Check the source has description.",
+            "status": hook_properties.get("status_code"),
+            "execution_time": end_time - start_time,
+            "is_pytest": script_args.get("is_test"),
+        },
+    )
+    return hook_properties.get("status_code")
+
+
+if __name__ == "__main__":
+    exit(main()) 

--- a/setup.cfg
+++ b/setup.cfg
@@ -57,6 +57,7 @@ console_scripts =
     check-source-childs = dbt_checkpoint.check_source_childs:main
     check-source-columns-have-desc = dbt_checkpoint.check_source_columns_have_desc:main
     check-source-has-all-columns = dbt_checkpoint.check_source_has_all_columns:main
+    check-source-has-description = dbt_checkpoint.check_source_has_description:main
     check-source-table-has-description = dbt_checkpoint.check_source_table_has_description:main
     check-source-has-freshness = dbt_checkpoint.check_source_has_freshness:main
     check-source-has-loader = dbt_checkpoint.check_source_has_loader:main

--- a/tests/unit/test_check_source_has_description.py
+++ b/tests/unit/test_check_source_has_description.py
@@ -1,0 +1,80 @@
+import pytest
+
+from dbt_checkpoint.check_source_has_description import main
+
+# Input schema, expected return value
+TESTS = (
+    (
+        """
+sources:
+-   name: with_description
+    description: test
+    tables:
+    -   name: test
+    """,
+        True,
+        True,
+        0,
+    ),
+    (
+        """
+sources:
+-   name: with_description
+    description: test
+    tables:
+    -   name: test
+    """,
+        False,
+        True,
+        1,
+    ),
+    (
+        """
+sources:
+-   name: without_description
+    tables:
+    -   name: test
+    """,
+        True,
+        True,
+        1,
+    ),
+    (
+        """
+sources:
+-   name: with_description
+    description: test
+    tables:
+    -   name: test
+    """,
+        True,
+        False,
+        0,
+    ),
+)
+
+
+@pytest.mark.parametrize(
+    ("input_schema", "valid_manifest", "valid_config", "expected_status_code"), TESTS
+)
+def test_check_source_has_description(
+    input_schema,
+    valid_manifest,
+    valid_config,
+    expected_status_code,
+    tmpdir,
+    manifest_path_str,
+    config_path_str,
+):
+    input_args = ["--is_test"]
+
+    if valid_manifest:
+        input_args.extend(["--manifest", manifest_path_str])
+
+    if valid_config:
+        input_args.extend(["--config", config_path_str])
+
+    yml_file = tmpdir.join("schema.yml")
+    yml_file.write(input_schema)
+    status_code = main(argv=[str(yml_file), *input_args])
+    assert status_code == expected_status_code 


### PR DESCRIPTION
## Description

This PR introduces the `check-source-has-description` pre-commit hook. This hook ensures that all dbt sources declared in YAML files have a corresponding `description` property.

This functionality is similar to the existing `check-source-has-loader` hook but verifies the presence of the source description instead.

## Changes Included

- Added `dbt_checkpoint/check_source_has_description.py` with the hook logic.
- Added `tests/unit/test_check_source_has_description.py` with unit tests.
- Updated `.pre-commit-hooks.yaml` to include the new hook.
- Updated `README.md` hook list.
- Updated `setup.cfg` entry points.
- Updated `HOOKS.md` documentation.

## Motivation

Enforces documentation best practices by requiring descriptions for all dbt sources, improving data discoverability and understanding.