### PR TITLE
allow null freshness on source

### DIFF
--- a/dbt_checkpoint/check_source_has_freshness.py
+++ b/dbt_checkpoint/check_source_has_freshness.py
@@ -27,7 +27,7 @@ def has_freshness(
     for schema in schemas:
         source = schema.source_schema
         table = schema.table_schema
-        merged = {**source.get("freshness", {}), **table.get("freshness", {})}
+        merged = {**(source.get("freshness") or {}), **(table.get("freshness") or {})}
         # if filter is present, remove it because it's not a dictionary like
         # warn_after or error_after
         if "filter" in merged.keys():


### PR DESCRIPTION
Resolves: https://github.com/dbt-checkpoint/dbt-checkpoint/issues/280

# Context
[dbt allows null freshness](https://docs.getdbt.com/faqs/Project/exclude-table-from-freshness)
```
sources:
  - name: jaffle_shop
    database: raw
    freshness:
      warn_after: {count: 12, period: hour}
      error_after: {count: 24, period: hour}
    loaded_at_field: _etl_loaded_at
    tables:
      - name: orders
      - name: product_skus
        freshness: null # do not check freshness for this table
```

Current implementation fails when the above is present
```
in has_freshness
    merged = {**source.get("freshness", {}), **table.get("freshness", {})}
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: 'NoneType' object is not a mapping
```

# Solution
`source.get("freshness") or {}`
- If the key "freshness" doesn't exist → returns None, then or {} gives {}
- If the key "freshness" exists but has value None → returns None, then or {} gives {}
