### PR TITLE
CI/CD README.md Update to git diff

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,19 +268,22 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
 
       - name: Setup Python
         uses: actions/setup-python@v2
 
-      - id: Get file changes
-        uses: trilom/file-changes-action@v1.2.4
-        with:
-          output: " "
+      - name: Get all changed files
+        id: get_changed_files
+        run: |
+          files=$(git diff --name-only origin/main...HEAD || true)
+          echo "changed_files=$files" >> $GITHUB_OUTPUT
 
       - name: Run dbt checkpoint
         uses: dbt-checkpoint/action@v0.1
         with:
-          extra_args: --files ${{ steps.get_file_changes.outputs.files}}
+          extra_args: --files ${{ steps.get_changed_files.outputs.files }}
           dbt_version: 1.6.3
           dbt_adapter: dbt-snowflake
 ```


### PR DESCRIPTION
## Description

In the CI/CD section of `README.md`, the sample code currently uses the `trilom/file-changes-action@v1.2.4` GitHub Action to identify which files have changed and should be checked by `dbt-checkpoint`. However, this repository has not been updated since 2020 and lacks many of the features present within git diff.
## Solution

This update replaces the Trilom dependency with a native `git diff` command, leveraging GitHub's built-in functionality. This approach removes the need for a third-party action and provides finer control over which files are included. I implemented this solution in my own repository, [`dbt-checkpoint-test`](https://github.com/anthonydelphy/dbt-checkpoint-test), to ensure that only `.sql` files are tested.

For example, `$(git diff --name-only "$base_sha" "$head_sha" -- '*.sql')` pull only .sql files that have been changed since the branch was created.

## Technical Details

- **`fetch-depth: 0`** – In the `actions/checkout` step, the fetch depth has been set to `0` to retrieve the full Git history.
- **Replacing Trilom with `git diff`** – This change uses built-in Git functionality to detect changed files from the start of the branch. It avoids reliance on outdated third-party tools and gives developers more flexibility. Any logic you can apply via the command line can now be incorporated directly into the CI/CD workflow.

## Testing

As mentioned above, I tested this setup in my repository: [`dbt-checkpoint-test`](https://github.com/anthonydelphy/dbt-checkpoint-test).

The repository is based on the dbt Jaffle Shop example and is used for testing dbt CI/CD workflows. By using `git diff`, I was able to filter for `.sql` files only and display the results directly in the GitHub Actions output.

<img width="1432" height="739" alt="image" src="https://github.com/user-attachments/assets/bc6ba212-9067-4fb0-8eec-3744b5117532" />
