### PR TITLE
Added hook to check for mandatory columns of a given type.

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -38,7 +38,7 @@
   language: python
   types_or: [sql, yaml]
 - id: check-model-has-columns-with-types
-  name: Check the model has required columns with specified types
+  name: Check the model has columns with given types
   description: Ensures that model has mandatory audit columns like _loaded_at, _updated_at etc with correct types.
   entry: check-model-has-columns-with-types
   language: python

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -37,6 +37,12 @@
   entry: check-model-has-all-columns
   language: python
   types_or: [sql, yaml]
+- id: check-model-has-columns-with-types
+  name: Check the model has required columns with specified types
+  description: Ensures that model has mandatory audit columns like _loaded_at, _updated_at etc with correct types.
+  entry: check-model-has-columns-with-types
+  language: python
+  types_or: [sql, yaml]
 - id: check-model-has-contract
   name: Check model has contract
   description: Check model has contract enforced = True

--- a/dbt_checkpoint/check_model_has_columns_with_types.py
+++ b/dbt_checkpoint/check_model_has_columns_with_types.py
@@ -1,0 +1,169 @@
+import argparse
+import os
+import time
+from typing import Any, Dict, List, Optional, Sequence, Tuple
+
+from dbt_checkpoint.tracking import dbtCheckpointTracking
+from dbt_checkpoint.utils import (
+    JsonOpenError,
+    add_catalog_args,
+    add_default_args,
+    get_dbt_catalog,
+    get_dbt_manifest,
+    get_missing_file_paths,
+    get_model_sqls,
+    get_models,
+    red,
+    yellow,
+)
+
+
+def check_required_columns(
+    catalog_columns: Dict[str, Any], required_columns: List[Dict[str, str]]
+) -> Tuple[List[str], List[str]]:
+    missing_columns = []
+    wrong_type_columns = []
+    
+    catalog_cols_lower = {col.lower(): col_info for col, col_info in catalog_columns.items()}
+    
+    for req_col in required_columns:
+        col_name = req_col["name"].lower()
+        col_type = req_col["type"].upper()
+        
+        if col_name not in catalog_cols_lower:
+            missing_columns.append(f"{req_col['name']} ({req_col['type']})")
+        else:
+            actual_type = catalog_cols_lower[col_name].get("type", "").upper()
+            if actual_type != col_type:
+                wrong_type_columns.append(
+                    f"{req_col['name']} (expected: {req_col['type']}, actual: {actual_type})"
+                )
+    
+    return missing_columns, wrong_type_columns
+
+
+def check_model_columns_with_types(
+    paths: Sequence[str],
+    manifest: Dict[str, Any],
+    catalog: Dict[str, Any],
+    required_columns: List[Dict[str, str]],
+    exclude_pattern: str,
+    include_disabled: bool = False,
+) -> int:
+    paths = get_missing_file_paths(
+        paths, manifest, extensions=[".sql"], exclude_pattern=exclude_pattern
+    )
+
+    status_code = 0
+    sqls = get_model_sqls(paths, manifest, include_disabled)
+    filenames = set(sqls.keys())
+
+    models = get_models(manifest, filenames, include_disabled=include_disabled)
+
+    catalog_nodes = catalog.get("nodes", {})
+
+    for model in models:
+        catalog_node = catalog_nodes.get(model.model_id, {})
+        if catalog_node:
+            missing_columns, wrong_type_columns = check_required_columns(
+                catalog_columns=catalog_node.get("columns", {}),
+                required_columns=required_columns,
+            )
+            
+            if missing_columns or wrong_type_columns:
+                status_code = 1
+                model_file = red(sqls.get(model.filename))
+                print(f"Model {model_file} has column issues:")
+                
+                if missing_columns:
+                    print(f"  Missing required columns:")
+                    for col in missing_columns:
+                        print(f"    - {yellow(col)}")
+                
+                if wrong_type_columns:
+                    print(f"  Columns with incorrect types:")
+                    for col in wrong_type_columns:
+                        print(f"    - {red(col)}")
+                print()
+        else:
+            status_code = 1
+            print(
+                f"Unable to find model `{red(model.model_id)}` in catalog file. "
+                f"Make sure you run `dbt docs generate` before executing this hook."
+            )
+    return status_code
+
+
+def main(argv: Optional[Sequence[str]] = None) -> int:
+    parser = argparse.ArgumentParser()
+    add_default_args(parser)
+    add_catalog_args(parser)
+    parser.add_argument(
+        "--columns",
+        required=True,
+        help='Required columns with types in JSON format. Example: [{"name": "_loaded_at", "type": "timestamp"}, {"name": "_updated_at", "type": "timestamp"}]',
+        metavar='[{"name": "_loaded_at", "type": "timestamp"}]',
+        dest="columns",
+        type=str,
+    )
+
+    args = parser.parse_args(argv)
+
+    try:
+        manifest = get_dbt_manifest(args)
+    except JsonOpenError as e:
+        print(f"Unable to load manifest file ({e})")
+        return 1
+
+    try:
+        catalog = get_dbt_catalog(args)
+    except JsonOpenError as e:
+        print(f"Unable to load catalog file ({e})")
+        return 1
+
+    try:
+        import json
+        required_columns = json.loads(args.columns)
+    except json.JSONDecodeError as e:
+        print(f"Invalid JSON in --columns argument: {e}")
+        return 1
+
+    if not isinstance(required_columns, list):
+        print("--columns argument must be a JSON array")
+        return 1
+
+    for col in required_columns:
+        if not isinstance(col, dict) or "name" not in col or "type" not in col:
+            print("Each column in --columns must be an object with 'name' and 'type' keys")
+            return 1
+
+    start_time = time.time()
+    status_code = check_model_columns_with_types(
+        paths=args.filenames,
+        manifest=manifest,
+        catalog=catalog,
+        required_columns=required_columns,
+        exclude_pattern=args.exclude,
+        include_disabled=args.include_disabled,
+    )
+    end_time = time.time()
+    script_args = vars(args)
+
+    tracker = dbtCheckpointTracking(script_args=script_args)
+    tracker.track_hook_event(
+        event_name="Hook Executed",
+        manifest=manifest,
+        event_properties={
+            "hook_name": os.path.basename(__file__),
+            "description": "Check model has columns with specified types",
+            "status": status_code,
+            "execution_time": end_time - start_time,
+            "is_pytest": script_args.get("is_test"),
+        },
+    )
+
+    return status_code
+
+
+if __name__ == "__main__":
+    exit(main())

--- a/setup.cfg
+++ b/setup.cfg
@@ -35,6 +35,7 @@ console_scripts =
     check-macro-arguments-have-desc = dbt_checkpoint.check_macro_arguments_have_desc:main
     check-model-columns-have-desc = dbt_checkpoint.check_model_columns_have_desc:main
     check-model-has-all-columns = dbt_checkpoint.check_model_has_all_columns:main
+    check-model-has-columns-with-types = dbt_checkpoint.check_model_has_columns_with_types:main
     check-model-has-contract = dbt_checkpoint.check_model_has_contract:main
     check-model-has-constraints = dbt_checkpoint.check_model_has_constraints:main
     check-model-has-description = dbt_checkpoint.check_model_has_description:main

--- a/tests/unit/test_check_model_has_columns_with_types.py
+++ b/tests/unit/test_check_model_has_columns_with_types.py
@@ -1,0 +1,163 @@
+import pytest
+
+from dbt_checkpoint.check_model_has_columns_with_types import main
+
+# Input args, valid manifest, valid_catalog, valid_config, expected return value
+TESTS = (
+    # Test with matching columns and types
+    (
+        ["aa/bb/catalog_cols.sql", "--columns", '[{"name": "col1", "type": "text"}]', "--is_test"],
+        True,
+        True,
+        True,
+        0,
+    ),
+    # Test with missing column
+    (
+        ["aa/bb/catalog_cols.sql", "--columns", '[{"name": "missing_col", "type": "text"}]', "--is_test"],
+        True,
+        True,
+        True,
+        1,
+    ),
+    # Test with wrong type
+    (
+        ["aa/bb/catalog_cols.sql", "--columns", '[{"name": "col1", "type": "integer"}]', "--is_test"],
+        True,
+        True,
+        True,
+        1,
+    ),
+    # Test with multiple columns - all correct
+    (
+        ["aa/bb/catalog_cols.sql", "--columns", '[{"name": "col1", "type": "text"}, {"name": "col2", "type": "text"}]', "--is_test"],
+        True,
+        True,
+        True,
+        0,
+    ),
+    # Test with multiple columns - one missing, one wrong type
+    (
+        ["aa/bb/catalog_cols.sql", "--columns", '[{"name": "col1", "type": "integer"}, {"name": "missing_col", "type": "text"}]', "--is_test"],
+        True,
+        True,
+        True,
+        1,
+    ),
+    # Test without catalog
+    (
+        ["aa/bb/catalog_cols.sql", "--columns", '[{"name": "col1", "type": "text"}]', "--is_test"],
+        True,
+        False,
+        True,
+        1,
+    ),
+    # Test without manifest
+    (
+        ["aa/bb/catalog_cols.sql", "--columns", '[{"name": "col1", "type": "text"}]', "--is_test"],
+        False,
+        True,
+        True,
+        1,
+    ),
+    # Test model not in catalog
+    (
+        ["aa/bb/without_catalog.sql", "--columns", '[{"name": "col1", "type": "text"}]', "--is_test"],
+        True,
+        True,
+        True,
+        1,
+    ),
+    # Test case insensitive matching
+    (
+        ["aa/bb/catalog_cols.sql", "--columns", '[{"name": "COL1", "type": "TEXT"}]', "--is_test"],
+        True,
+        True,
+        True,
+        0,
+    ),
+)
+
+
+@pytest.mark.parametrize(
+    (
+        "input_args",
+        "valid_manifest",
+        "valid_catalog",
+        "valid_config",
+        "expected_status_code",
+    ),
+    TESTS,
+)
+def test_check_model_has_columns_with_types(
+    input_args,
+    valid_manifest,
+    valid_catalog,
+    valid_config,
+    expected_status_code,
+    manifest_path_str,
+    catalog_path_str,
+    config_path_str,
+):
+    if valid_manifest:
+        input_args.extend(["--manifest", manifest_path_str])
+
+    if valid_catalog:
+        input_args.extend(["--catalog", catalog_path_str])
+
+    if valid_config:
+        input_args.extend(["--config", config_path_str])
+
+    status_code = main(input_args)
+    assert status_code == expected_status_code
+
+
+def test_invalid_json_columns(manifest_path_str, catalog_path_str, config_path_str):
+    input_args = [
+        "aa/bb/catalog_cols.sql",
+        "--columns",
+        "invalid json",
+        "--is_test",
+        "--manifest",
+        manifest_path_str,
+        "--catalog",
+        catalog_path_str,
+        "--config",
+        config_path_str,
+    ]
+    status_code = main(input_args)
+    assert status_code == 1
+
+
+def test_non_array_columns(manifest_path_str, catalog_path_str, config_path_str):
+    input_args = [
+        "aa/bb/catalog_cols.sql",
+        "--columns",
+        '{"name": "col1", "type": "text"}',
+        "--is_test",
+        "--manifest",
+        manifest_path_str,
+        "--catalog",
+        catalog_path_str,
+        "--config",
+        config_path_str,
+    ]
+    status_code = main(input_args)
+    assert status_code == 1
+
+
+def test_invalid_column_object(manifest_path_str, catalog_path_str, config_path_str):
+    input_args = [
+        "aa/bb/catalog_cols.sql",
+        "--columns",
+        '[{"name": "col1"}]',  # Missing type
+        "--is_test",
+        "--manifest",
+        manifest_path_str,
+        "--catalog",
+        catalog_path_str,
+        "--config",
+        config_path_str,
+    ]
+    status_code = main(input_args)
+    assert status_code == 1


### PR DESCRIPTION
Add check-model-has-columns-with-types hook

  Summary

  - Add new pre-commit hook to ensure models have mandatory audit columns with specified data types
  - Validates presence and correct types for required columns like _loaded_at, _updated_at, etc.
  - Provides clear error reporting for missing columns and type mismatches

  Changes

  - New hook: check-model-has-columns-with-types
  - Implementation: dbt_checkpoint/check_model_has_columns_with_types.py
  - Tests: Added tests covering various scenarios
  - Configuration: Updated setup.cfg and .pre-commit-hooks.yaml

  Features

  - ✅ Column existence validation - Checks required columns are present
  - ✅ Data type validation - Ensures columns have correct types (e.g., timestamp, string)
  - ✅ Case-insensitive matching - Works with different column name casings

  Usage
```
  - id: check-model-has-columns-with-types
    args: ['--columns', '[{"name": "_loaded_at", "type": "timestamp"}, {"name": "_updated_at", "type": "timestamp"}]']
```

  Example Output

  Model models/my_model.sql has column issues:
    Missing required columns:
      - _loaded_at (timestamp)
    Columns with incorrect types:
      - _updated_at (expected: timestamp, actual: text)

  Test Coverage

  - ✅ Covers success/failure scenarios
  - ✅ Tests JSON validation and error handling
  - ✅ No regressions in existing functionality

  ---

  This addresses the common need to enforce audit column standards across dbt models, ensuring data lineage and tracking requirements are consistently met.

