### PR TITLE
Fix: Update test with dbt 1.10 [PropertyMovedToConfigDeprecation](htt…

### DIFF
--- a/dbt_checkpoint/check_source_has_freshness.py
+++ b/dbt_checkpoint/check_source_has_freshness.py
@@ -27,6 +27,10 @@ def has_freshness(
     for schema in schemas:
         source = schema.source_schema
         table = schema.table_schema
+        if 'config' in source:
+            source=source["config"]
+        if 'config' in table:
+            table=table["config"]
         merged = {**source.get("freshness", {}), **table.get("freshness", {})}
         # if filter is present, remove it because it's not a dictionary like
         # warn_after or error_after

--- a/dbt_checkpoint/check_source_has_meta_keys.py
+++ b/dbt_checkpoint/check_source_has_meta_keys.py
@@ -29,8 +29,14 @@ def has_meta_key(
     schemas = get_source_schemas(ymls, include_disabled=include_disabled)
 
     for schema in schemas:
-        schema_meta = set(schema.source_schema.get("meta", {}).keys())
-        table_meta = set(schema.table_schema.get("meta", {}).keys())
+        if "config" in schema.source_schema:
+            schema_meta = set(schema.source_schema["config"].get("meta", {}).keys())
+        else:
+            schema_meta = set(schema.source_schema.get("meta", {}).keys())
+        if "config" in schema.table_schema:
+            table_meta = set(schema.table_schema["config"].get("meta", {}).keys())
+        else:
+            table_meta = set(schema.table_schema.get("meta", {}).keys())
         if allow_extra_keys:
             diff = not set(meta_keys).issubset(set(schema_meta | table_meta))
         else:

--- a/tests/unit/test_check_model_has_meta_keys.py
+++ b/tests/unit/test_check_model_has_meta_keys.py
@@ -14,6 +14,18 @@ TESTS = (
             "foo",
             "bar",
         ],
+        {"models": [{"name": "with_meta", "config": {"meta": {"foo": "bar"}}}]},
+        True,
+        True,
+        0,
+    ),
+    (
+        [
+            "aa/bb/with_meta.sql",
+            "--meta-keys",
+            "foo",
+            "bar",
+        ],
         {"models": [{"name": "with_meta", "meta": {"foo": "bar"}}]},
         True,
         True,

--- a/tests/unit/test_check_source_has_freshness.py
+++ b/tests/unit/test_check_source_has_freshness.py
@@ -8,6 +8,27 @@ TESTS = (
         """
 sources:
 -   name: test
+    config:
+        loaded_at_field: aa
+        freshness:
+            warn_after:
+                count: 12
+                period: hour
+            error_after:
+                count: 24
+                period: hour
+            filter: x > y
+    tables:
+    -   name: with_description
+    """,
+        True,
+        True,
+        0,
+    ),    
+    (
+        """
+sources:
+-   name: test
     loaded_at_field: aa
     freshness:
         warn_after:

--- a/tests/unit/test_check_source_has_meta_keys.py
+++ b/tests/unit/test_check_source_has_meta_keys.py
@@ -9,6 +9,22 @@ TESTS = (
 sources:
 -   name: src
     loader: test
+    config:
+        meta:
+            foo: test
+            bar: test
+    tables:
+    -   name: test
+    """,
+        True,
+        True,
+        0,
+    ),
+    (
+        """
+sources:
+-   name: src
+    loader: test
     meta:
         foo: test
         bar: test

--- a/tests/unit/test_check_source_tags.py
+++ b/tests/unit/test_check_source_tags.py
@@ -9,6 +9,22 @@ TESTS = (
 sources:
 -   name: src
     loader: test
+    config:
+        tags:
+        -   foo
+        -   bar
+    tables:
+    -   name: test
+    """,
+        True,
+        True,
+        0,
+    ),
+    (
+        """
+sources:
+-   name: src
+    loader: test
     tags:
     -   foo
     -   bar


### PR DESCRIPTION
Resolves #313 

Update dbt-checkpoint test to add a test with new `config` section, to be compliant with new deprecation in dbt 1.10.
See : https://docs.getdbt.com/reference/deprecations#propertymovedtoconfigdeprecation
