### PR TITLE
Fix: typo in check-script-has-no-table-name

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -134,7 +134,7 @@
   language: python
   types_or: [sql, yaml]
 - id: check-script-has-no-table-name
-  name: Check the script has not table name
+  name: Check the script has no table name
   description: Ensures that the script is using only source or ref macro to specify the table name.
   entry: check-script-has-no-table-name
   language: python


### PR DESCRIPTION
This PR fixes a simple typo in check-script-has-no-table-name