### PR TITLE
Feat/model meta accepted vals

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -63,6 +63,13 @@
   language: python
   types_or: [yaml, sql]
   require_serial: true # because we need to process YAML and SQL
+- id: check-model-meta-key-accepted-values
+  name: Check the model meta key has accepted values
+  description: Ensures that the model meta key has a value from the accepted values list.
+  entry: check-model-meta-key-accepted-values
+  language: python
+  types_or: [yaml, sql]
+  require_serial: true # because we need to process YAML and SQL
 - id: check-model-has-labels-keys
   name: Check the model has keys in the labels part
   description: Ensures that the model has a list of valid labels keys.

--- a/dbt_checkpoint/check_model_meta_key_accepted_values.py
+++ b/dbt_checkpoint/check_model_meta_key_accepted_values.py
@@ -1,0 +1,147 @@
+import argparse
+import os
+import time
+from typing import Any, Dict, Optional, Sequence, Set
+
+from dbt_checkpoint.tracking import dbtCheckpointTracking
+from dbt_checkpoint.utils import (
+    JsonOpenError,
+    add_default_args,
+    get_dbt_manifest,
+    get_filenames,
+    get_missing_file_paths,
+    get_model_schemas,
+    get_model_sqls,
+    get_models,
+    red,
+)
+
+
+def check_meta_key_accepted_values(
+    paths: Sequence[str],
+    manifest: Dict[str, Any],
+    meta_key: str,
+    accepted_values: Sequence[str],
+    exclude_pattern: str = "",
+    include_disabled: bool = False,
+) -> int:
+    # Discover related SQL files when yaml files are changed
+    paths = get_missing_file_paths(
+        paths, manifest, extensions=[".sql", ".yml", ".yaml"], exclude_pattern=exclude_pattern
+    )
+    
+    status_code = 0
+    ymls = get_filenames(paths, [".yml", ".yaml"])
+    sqls = get_model_sqls(paths, manifest, include_disabled)
+    filenames = set(sqls.keys())
+    accepted_set = set(accepted_values)
+    
+    # get manifest nodes that pre-commit found as changed
+    models = get_models(manifest, filenames, include_disabled=include_disabled)
+    # if user added schema but did not rerun the model
+    schemas = get_model_schemas(list(ymls.values()), filenames)
+    
+    # Check models from manifest
+    invalid_models: Set[str] = set()
+    for model in models:
+        meta = model.node.get("meta", {})
+        if meta_key not in meta:
+            invalid_models.add(model.filename)
+        elif meta.get(meta_key) not in accepted_set:
+            invalid_models.add(model.filename)
+    
+    # Check schemas from yml files
+    for schema in schemas:
+        meta = schema.schema.get("meta", {})
+        if meta_key not in meta:
+            invalid_models.add(schema.model_name)
+        elif meta.get(meta_key) not in accepted_set:
+            invalid_models.add(schema.model_name)
+    
+    # Find models that are invalid (missing key or invalid value)
+    invalid = filenames.intersection(invalid_models)
+    
+    for model in invalid:
+        status_code = 1
+        meta = {}
+        # Try to get meta from model or schema
+        for m in models:
+            if m.filename == model:
+                meta = m.node.get("meta", {})
+                break
+        if not meta:
+            for s in schemas:
+                if s.model_name == model:
+                    meta = s.schema.get("meta", {})
+                    break
+        
+        if meta_key not in meta:
+            print(
+                f"{red(sqls.get(model))}: "
+                f"meta key '{meta_key}' is missing. Accepted values: {', '.join(accepted_values)}",
+            )
+        else:
+            actual_value = meta.get(meta_key)
+            print(
+                f"{red(sqls.get(model))}: "
+                f"meta key '{meta_key}' has value '{actual_value}' which is not in accepted values: {', '.join(accepted_values)}",
+            )
+    
+    return status_code
+
+
+def main(argv: Optional[Sequence[str]] = None) -> int:
+    parser = argparse.ArgumentParser()
+    add_default_args(parser)
+    parser.add_argument(
+        "--meta-key",
+        type=str,
+        required=True,
+        help="Name of the meta key to check (e.g. 'domain').",
+    )
+    parser.add_argument(
+        "--accepted-values",
+        nargs="+",
+        required=True,
+        help="List of accepted values for the meta key (e.g. 'sales finance hr').",
+    )
+    
+    args = parser.parse_args(argv)
+
+    try:
+        manifest = get_dbt_manifest(args)
+    except JsonOpenError as e:
+        print(f"Unable to load manifest file ({e})")
+        return 1
+
+    start_time = time.time()
+    status_code = check_meta_key_accepted_values(
+        paths=args.filenames,
+        manifest=manifest,
+        meta_key=args.meta_key,
+        accepted_values=args.accepted_values,
+        exclude_pattern=args.exclude,
+        include_disabled=args.include_disabled,
+    )
+    end_time = time.time()
+    script_args = vars(args)
+
+    tracker = dbtCheckpointTracking(script_args=script_args)
+    tracker.track_hook_event(
+        event_name="Hook Executed",
+        manifest=manifest,
+        event_properties={
+            "hook_name": os.path.basename(__file__),
+            "description": "Check model meta key has accepted values",
+            "status": status_code,
+            "execution_time": end_time - start_time,
+            "is_pytest": script_args.get("is_test"),
+        },
+    )
+
+    return status_code
+
+
+if __name__ == "__main__":
+    exit(main())
+

--- a/setup.cfg
+++ b/setup.cfg
@@ -39,6 +39,7 @@ console_scripts =
     check-model-has-constraints = dbt_checkpoint.check_model_has_constraints:main
     check-model-has-description = dbt_checkpoint.check_model_has_description:main
     check-model-has-meta-keys = dbt_checkpoint.check_model_has_meta_keys:main
+    check-model-meta-key-accepted-values = dbt_checkpoint.check_model_meta_key_accepted_values:main
     check-model-has-labels-keys = dbt_checkpoint.check_model_has_labels_keys:main
     check-model-has-properties-file = dbt_checkpoint.check_model_has_properties_file:main
     check-model-has-tests-by-name = dbt_checkpoint.check_model_has_tests_by_name:main

--- a/tests/unit/test_check_model_meta_key_accepted_values.py
+++ b/tests/unit/test_check_model_meta_key_accepted_values.py
@@ -1,0 +1,199 @@
+from unittest.mock import mock_open
+from unittest.mock import patch
+
+import pytest
+
+from dbt_checkpoint.check_model_meta_key_accepted_values import main
+
+# Input args, valid manifest, expected return value
+TESTS = (
+    (
+        [
+            "aa/bb/with_meta.sql",
+            "--meta-key",
+            "domain",
+            "--accepted-values",
+            "sales",
+            "finance",
+            "hr",
+        ],
+        {"models": [{"name": "with_meta", "meta": {"domain": "sales"}}]},
+        True,
+        True,
+        0,
+    ),
+    (
+        [
+            "aa/bb/with_meta.sql",
+            "--meta-key",
+            "domain",
+            "--accepted-values",
+            "sales",
+            "finance",
+            "hr",
+        ],
+        {"models": [{"name": "with_meta", "meta": {"domain": "invalid"}}]},
+        True,
+        True,
+        1,
+    ),
+    (
+        [
+            "aa/bb/without_meta.sql",
+            "--meta-key",
+            "domain",
+            "--accepted-values",
+            "sales",
+            "finance",
+            "hr",
+        ],
+        {"models": [{"name": "without_meta"}]},
+        True,
+        True,
+        1,
+    ),
+    (
+        [
+            "aa/bb/with_meta.sql",
+            "--meta-key",
+            "domain",
+            "--accepted-values",
+            "sales",
+            "finance",
+        ],
+        {"models": [{"name": "with_meta", "meta": {"domain": "sales", "other": "value"}}]},
+        True,
+        True,
+        0,
+    ),
+    (
+        [
+            "aa/bb/with_meta.sql",
+            "--meta-key",
+            "domain",
+            "--accepted-values",
+            "sales",
+            "finance",
+            "hr",
+        ],
+        {"models": [{"name": "with_meta", "meta": {"domain": "hr"}}]},
+        True,
+        True,
+        0,
+    ),
+)
+
+
+@pytest.mark.parametrize(
+    ("input_args", "schema", "valid_manifest", "valid_config", "expected_status_code"),
+    TESTS,
+)
+def test_check_model_meta_key_accepted_values(
+    input_args,
+    schema,
+    valid_manifest,
+    valid_config,
+    expected_status_code,
+    manifest_path_str,
+    config_path_str,
+):
+    if valid_manifest:
+        input_args.extend(["--manifest", manifest_path_str])
+    if valid_config:
+        input_args.extend(["--config", config_path_str])
+    with patch("builtins.open", mock_open(read_data="data")):
+        with patch("dbt_checkpoint.utils.safe_load") as mock_safe_load:
+            mock_safe_load.return_value = schema
+    status_code = main(input_args)
+    assert status_code == expected_status_code
+
+
+@pytest.mark.parametrize("extension", [("yml"), ("yaml")])
+def test_check_model_meta_key_accepted_values_in_changed(extension, tmpdir, manifest_path_str):
+    schema_yml = """
+version: 2
+
+models:
+-   name: in_schema_meta
+    meta:
+        domain: sales
+-   name: xxx
+    """
+    yml_file = tmpdir.join(f"schema.{extension}")
+    yml_file.write(schema_yml)
+    result = main(
+        argv=[
+            "in_schema_meta.sql",
+            str(yml_file),
+            "--meta-key",
+            "domain",
+            "--accepted-values",
+            "sales",
+            "finance",
+            "hr",
+            "--manifest",
+            manifest_path_str,
+        ],
+    )
+    assert result == 0
+
+
+@pytest.mark.parametrize("extension", [("yml"), ("yaml")])
+def test_check_model_meta_key_accepted_values_invalid_value(extension, tmpdir, manifest_path_str):
+    schema_yml = """
+version: 2
+
+models:
+-   name: in_schema_meta
+    meta:
+        domain: invalid_domain
+-   name: xxx
+    """
+    yml_file = tmpdir.join(f"schema.{extension}")
+    yml_file.write(schema_yml)
+    result = main(
+        argv=[
+            "in_schema_meta.sql",
+            str(yml_file),
+            "--meta-key",
+            "domain",
+            "--accepted-values",
+            "sales",
+            "finance",
+            "hr",
+            "--manifest",
+            manifest_path_str,
+        ],
+    )
+    assert result == 1
+
+
+@pytest.mark.parametrize("extension", [("yml"), ("yaml")])
+def test_check_model_meta_key_accepted_values_missing_key(extension, tmpdir, manifest_path_str):
+    schema_yml = """
+version: 2
+
+models:
+-   name: in_schema_meta
+    meta:
+        other_key: value
+-   name: xxx
+    """
+    yml_file = tmpdir.join(f"schema.{extension}")
+    yml_file.write(schema_yml)
+    result = main(
+        argv=[
+            "in_schema_meta.sql",
+            str(yml_file),
+            "--meta-key",
+            "domain",
+            "--accepted-values",
+            "sales",
+            "finance",
+            "hr",
+            "--manifest",
+            manifest_path_str,
+        ],
+    )
+    assert result == 1
+


### PR DESCRIPTION
Draft of an idea about adding a new hook to check that the value for a specific meta key falls within an accepted list of values. 

An example usage of this hook would be enforcing something a model's `domain` meta key is one of `[sales, hr, finance, all]` or something like that. 

I also thought about passing more args to `check-model-has-meta-keys` to achieve the same thing. Anyway, just sharing for now