### PR TITLE
Support for dbt 1.11 by removing deprecated selection method

### DIFF
--- a/dbt_checkpoint/dbt_compile.py
+++ b/dbt_checkpoint/dbt_compile.py
@@ -32,7 +32,7 @@ def prepare_cmd(
         dbt_models = models
     else:
         dbt_models = paths_to_dbt_models(paths, prefix, postfix)
-    cmd = ["dbt", *global_flags, "compile", "-m", *dbt_models, *cmd_flags]
+    cmd = ["dbt", *global_flags, "compile", "--select", *dbt_models, *cmd_flags]
     return extend_dbt_project_dir_flag(cmd, cmd_flags, dbt_project_dir)
 
 

--- a/dbt_checkpoint/dbt_run.py
+++ b/dbt_checkpoint/dbt_run.py
@@ -32,7 +32,7 @@ def prepare_cmd(
     else:
         dbt_models = paths_to_dbt_models(paths, prefix, postfix)
     dbt_project_dir = config.get("dbt-project-dir")
-    cmd = ["dbt", *global_flags, "run", "-m", *dbt_models, *cmd_flags]
+    cmd = ["dbt", *global_flags, "run", "--select", *dbt_models, *cmd_flags]
     return extend_dbt_project_dir_flag(cmd, cmd_flags, dbt_project_dir)
 
 

--- a/dbt_checkpoint/dbt_test.py
+++ b/dbt_checkpoint/dbt_test.py
@@ -32,7 +32,7 @@ def prepare_cmd(
     else:
         dbt_models = paths_to_dbt_models(paths, prefix, postfix)
     dbt_project_dir = config.get("dbt-project-dir")
-    cmd = ["dbt", *global_flags, "test", "-m", *dbt_models, *cmd_flags]
+    cmd = ["dbt", *global_flags, "test", "--select", *dbt_models, *cmd_flags]
     return extend_dbt_project_dir_flag(cmd, cmd_flags, dbt_project_dir)
 
 

--- a/tests/unit/test_dbt_compile.py
+++ b/tests/unit/test_dbt_compile.py
@@ -30,41 +30,41 @@ def test_dbt_compile_error():
 @pytest.mark.parametrize(
     "files,global_flags,cmd_flags,models,expected",
     [
-        (["/aa/bb/cc.txt"], None, None, None, ["dbt", "compile", "-m", "cc"]),
+        (["/aa/bb/cc.txt"], None, None, None, ["dbt", "compile", "--select", "cc"]),
         (
             ["/aa/bb/cc.txt"],
             ["++debug", "++no-write-json"],
             None,
             None,
-            ["dbt", "--debug", "--no-write-json", "compile", "-m", "cc"],
+            ["dbt", "--debug", "--no-write-json", "compile", "--select", "cc"],
         ),
         (
             ["/aa/bb/cc.txt"],
             None,
             ["+t", "prod"],
             None,
-            ["dbt", "compile", "-m", "cc", "-t", "prod"],
+            ["dbt", "compile", "--select", "cc", "-t", "prod"],
         ),
         (
             ["/aa/bb/cc.txt"],
             "",
             ["+t", "prod"],
             None,
-            ["dbt", "compile", "-m", "cc", "-t", "prod"],
+            ["dbt", "compile", "--select", "cc", "-t", "prod"],
         ),
         (
             ["/aa/bb/cc.txt"],
             None,
             None,
             [],
-            ["dbt", "compile", "-m", "cc"],
+            ["dbt", "compile", "--select", "cc"],
         ),
         (
             ["/aa/bb/cc.txt"],
             None,
             None,
             ["state:modified"],
-            ["dbt", "compile", "-m", "state:modified"],
+            ["dbt", "compile", "--select", "state:modified"],
         ),
     ],
 )

--- a/tests/unit/test_dbt_run.py
+++ b/tests/unit/test_dbt_run.py
@@ -30,41 +30,41 @@ def test_dbt_run_error():
 @pytest.mark.parametrize(
     "files,global_flags,cmd_flags,models,expected",
     [
-        (["/aa/bb/cc.txt"], None, None, None, ["dbt", "run", "-m", "cc"]),
+        (["/aa/bb/cc.txt"], None, None, None, ["dbt", "run", "--select", "cc"]),
         (
             ["/aa/bb/cc.txt"],
             ["++debug", "++no-write-json"],
             None,
             None,
-            ["dbt", "--debug", "--no-write-json", "run", "-m", "cc"],
+            ["dbt", "--debug", "--no-write-json", "run", "--select", "cc"],
         ),
         (
             ["/aa/bb/cc.txt"],
             None,
             ["+t", "prod"],
             None,
-            ["dbt", "run", "-m", "cc", "-t", "prod"],
+            ["dbt", "run", "--select", "cc", "-t", "prod"],
         ),
         (
             ["/aa/bb/cc.txt"],
             "",
             ["+t", "prod"],
             None,
-            ["dbt", "run", "-m", "cc", "-t", "prod"],
+            ["dbt", "run", "--select", "cc", "-t", "prod"],
         ),
         (
             ["/aa/bb/cc.txt"],
             None,
             None,
             [],
-            ["dbt", "run", "-m", "cc"],
+            ["dbt", "run", "--select", "cc"],
         ),
         (
             ["/aa/bb/cc.txt"],
             None,
             None,
             ["state:modified"],
-            ["dbt", "run", "-m", "state:modified"],
+            ["dbt", "run", "--select", "state:modified"],
         ),
     ],
 )

--- a/tests/unit/test_dbt_test.py
+++ b/tests/unit/test_dbt_test.py
@@ -30,41 +30,41 @@ def test_dbt_test_error():
 @pytest.mark.parametrize(
     "files,global_flags,cmd_flags,models,expected",
     [
-        (["/aa/bb/cc.txt"], None, None, None, ["dbt", "test", "-m", "cc"]),
+        (["/aa/bb/cc.txt"], None, None, None, ["dbt", "test", "--select", "cc"]),
         (
             ["/aa/bb/cc.txt"],
             ["++debug", "++no-write-json"],
             None,
             None,
-            ["dbt", "--debug", "--no-write-json", "test", "-m", "cc"],
+            ["dbt", "--debug", "--no-write-json", "test", "--select", "cc"],
         ),
         (
             ["/aa/bb/cc.txt"],
             None,
             ["+t", "prod"],
             None,
-            ["dbt", "test", "-m", "cc", "-t", "prod"],
+            ["dbt", "test", "--select", "cc", "-t", "prod"],
         ),
         (
             ["/aa/bb/cc.txt"],
             "",
             ["+t", "prod"],
             None,
-            ["dbt", "test", "-m", "cc", "-t", "prod"],
+            ["dbt", "test", "--select", "cc", "-t", "prod"],
         ),
         (
             ["/aa/bb/cc.txt"],
             None,
             None,
             [],
-            ["dbt", "test", "-m", "cc"],
+            ["dbt", "test", "--select", "cc"],
         ),
         (
             ["/aa/bb/cc.txt"],
             None,
             None,
             ["state:modified"],
-            ["dbt", "test", "-m", "state:modified"],
+            ["dbt", "test", "--select", "state:modified"],
         ),
     ],
 )


### PR DESCRIPTION
use of the flag `-m` in statements like `dbt run -m [models]` has been deprecated with dbt-core 1.11. I have replaced all occurrences with the standard `--select`.