### PR TITLE
fix: replace deprecated -m with --select and handle empty model list in dbt-docs-generate

### DIFF
--- a/HOOKS.md
+++ b/HOOKS.md
@@ -2292,6 +2292,8 @@ Run `dbt docs generate` command. The command is responsible for generating your 
 `--model-postfix`: Postfix dbt selector, for selecting children.</br>
 `--models`: dbt-checkpoint is by default running changed files. If you need to override that, e.g. in case of Slim CI (`state:modified`), you can use this option.
 
+> **Note:** When no filenames are passed (e.g. `pass_filenames: false`), the hook falls back to a full-project `dbt docs generate` without `--select`. This is useful when downstream hooks like `check-source-has-all-columns` need a complete `catalog.json`.
+
 #### Example
 
 ```yaml

--- a/dbt_checkpoint/dbt_docs_generate.py
+++ b/dbt_checkpoint/dbt_docs_generate.py
@@ -32,7 +32,10 @@ def prepare_cmd(
     else:
         dbt_models = paths_to_dbt_models(paths, prefix, postfix)
     dbt_project_dir = config.get("dbt-project-dir")
-    cmd = ["dbt", *global_flags, "docs", "generate", "-m", *dbt_models, *cmd_flags]
+    if dbt_models:
+        cmd = ["dbt", *global_flags, "docs", "generate", "--select", *dbt_models, *cmd_flags]
+    else:
+        cmd = ["dbt", *global_flags, "docs", "generate", *cmd_flags]
     return extend_dbt_project_dir_flag(cmd, cmd_flags, dbt_project_dir)
 
 

--- a/tests/unit/test_dbt_docs_generate.py
+++ b/tests/unit/test_dbt_docs_generate.py
@@ -31,41 +31,42 @@ def test_dbt_docs_generate_error():
 @pytest.mark.parametrize(
     "files,global_flags,cmd_flags,models,expected",
     [
-        (["/aa/bb/cc.txt"], None, None, None, ["dbt", "docs", "generate", "-m", "cc"]),
+        ([], None, None, None, ["dbt", "docs", "generate"]),
+        (["/aa/bb/cc.txt"], None, None, None, ["dbt", "docs", "generate", "--select", "cc"]),
         (
             ["/aa/bb/cc.txt"],
             ["++debug", "++no-write-json"],
             None,
             None,
-            ["dbt", "--debug", "--no-write-json", "docs", "generate", "-m", "cc"],
+            ["dbt", "--debug", "--no-write-json", "docs", "generate", "--select", "cc"],
         ),
         (
             ["/aa/bb/cc.txt"],
             None,
             ["+t", "prod"],
             None,
-            ["dbt", "docs", "generate", "-m", "cc", "-t", "prod"],
+            ["dbt", "docs", "generate", "--select", "cc", "-t", "prod"],
         ),
         (
             ["/aa/bb/cc.txt"],
             "",
             ["+t", "prod"],
             None,
-            ["dbt", "docs", "generate", "-m", "cc", "-t", "prod"],
+            ["dbt", "docs", "generate", "--select", "cc", "-t", "prod"],
         ),
         (
             ["/aa/bb/cc.txt"],
             None,
             None,
             [],
-            ["dbt", "docs", "generate", "-m", "cc"],
+            ["dbt", "docs", "generate", "--select", "cc"],
         ),
         (
             ["/aa/bb/cc.txt"],
             None,
             None,
             ["state:modified"],
-            ["dbt", "docs", "generate", "-m", "state:modified"],
+            ["dbt", "docs", "generate", "--select", "state:modified"],
         ),
     ],
 )


### PR DESCRIPTION
Fixes #340

## Summary

The `dbt-docs-generate` hook (introduced in v2.0.8 via PR #210) has two bugs:

1. **Uses deprecated `-m` flag** — All other hooks (`dbt_compile`, `dbt_run`, `dbt_test`) use `--select`. The `-m` flag was renamed in dbt Core v0.21, raises a warning in v1.10, and will error in Fusion.

2. **Crashes when no models are resolved** — The `-m` flag is always appended, even when the model list is empty. When a user sets `pass_filenames: false` to opt into full-project generation, the command becomes `dbt docs generate -m` (no args after `-m`), which exits with code 1.

## Changes

- **`dbt_checkpoint/dbt_docs_generate.py`**: Replace `-m` with `--select`, and only add it when `dbt_models` is non-empty. When empty, fall back to `dbt docs generate` (full project).
- **`tests/unit/test_dbt_docs_generate.py`**: Update all test expectations from `-m` to `--select`, and add a test case for empty paths `([], None, None, None, ["dbt", "docs", "generate"])`.
- **`HOOKS.md`**: Document the `pass_filenames: false` fallback behaviour.

## Why this matters

The file-scoped approach produces a partial `catalog.json`. Downstream hooks like `check-source-has-all-columns` that check source YAML files (which define many tables per schema) need a **complete** catalog. With this fix, users can set `pass_filenames: false` to get full catalog generation when needed.