### PR TITLE
feat(unify_column_description): do not escape unicode characters while unifying column description

### DIFF
--- a/dbt_checkpoint/unify_column_description.py
+++ b/dbt_checkpoint/unify_column_description.py
@@ -19,7 +19,7 @@ def _replace_desc(path: Path, column_name: str, description: str) -> None:
             if column_name == column.get("name"):
                 column["description"] = description
     with open(path, "w") as f:
-        yaml.dump(file, f, default_flow_style=False, sort_keys=False)
+        yaml.dump(file, f, default_flow_style=False, sort_keys=False, allow_unicode=True)
         print(
             f"{path}: replaced description of "
             f"column `{column_name}` for `{description}`"

--- a/tests/unit/test_unify_column_description.py
+++ b/tests/unit/test_unify_column_description.py
@@ -348,6 +348,56 @@ models:
     """,
         ["--ignore", "test1"],
     ),
+    # column description can contain unicode characters
+    (
+        """
+version: 2
+models:
+-   name: same_col_desc_1
+    columns:
+    -   name: test1
+        description: têst
+    -   name: test2
+        description: tèst
+-   name: same_col_desc_2
+    columns:
+    -   name: test1
+        description: têst
+    -   name: test2
+        description: tèst
+-   name: same_col_desc_3
+    columns:
+    -   name: test1
+        description: test1
+    -   name: test2
+        description: test2
+    """,
+        True,
+        True,
+        1,
+        """version: 2
+models:
+- name: same_col_desc_1
+  columns:
+  - name: test1
+    description: têst
+  - name: test2
+    description: tèst
+- name: same_col_desc_2
+  columns:
+  - name: test1
+    description: têst
+  - name: test2
+    description: tèst
+- name: same_col_desc_3
+  columns:
+  - name: test1
+    description: têst
+  - name: test2
+    description: tèst
+""",
+        [],
+    ),
 )
 
 
@@ -391,7 +441,6 @@ def test_replace_column_description(
     result = yml_file.read_text("utf-8")
     assert status_code == expected_status_code
     assert expected_result == result
-
 
 def test_replace_column_description_split(tmpdir, manifest_path_str):
     schema_yml1 = """


### PR DESCRIPTION
- use `allow_unicode=True` when writing updated yaml file
- add a unit test case