### PR TITLE
Expect meta nested under config for dbt versions >= 1.10

### DIFF
--- a/dbt_checkpoint/check_source_has_meta_keys.py
+++ b/dbt_checkpoint/check_source_has_meta_keys.py
@@ -29,8 +29,14 @@ def has_meta_key(
     schemas = get_source_schemas(ymls, include_disabled=include_disabled)
 
     for schema in schemas:
-        schema_meta = set(schema.source_schema.get("meta", {}).keys())
-        table_meta = set(schema.table_schema.get("meta", {}).keys())
+        schema_meta = {
+            *schema.source_schema.get("meta", {}).keys(),
+            *schema.source_schema.get("config", {}).get("meta", {}).keys()
+        }
+        table_meta = {
+            *schema.table_schema.get("meta", {}).keys(),
+            *schema.table_schema.get("config", {}).get("meta", {}).keys()
+        }
         if allow_extra_keys:
             diff = not set(meta_keys).issubset(set(schema_meta | table_meta))
         else:

--- a/tests/unit/test_check_source_has_meta_keys.py
+++ b/tests/unit/test_check_source_has_meta_keys.py
@@ -120,6 +120,119 @@ sources:
         False,
         0,
     ),
+    # After dbt Core v1.10, meta attribute is nested under config:
+    (
+        """
+sources:
+-   name: src
+    loader: test
+    config:
+        meta:
+            foo: test
+            bar: test
+    tables:
+    -   name: test
+    """,
+        True,
+        True,
+        0,
+    ),
+    (
+        """
+sources:
+-   name: src
+    loader: test
+    config:
+        meta:
+            foo: test
+            bar: test
+    tables:
+    -   name: test
+    """,
+        False,
+        True,
+        1,
+    ),
+    (
+        """
+sources:
+-   name: src
+    loader: test
+    config:
+        meta:
+            foo: test
+    tables:
+    -   name: test
+        config:
+            meta:
+                bar: test
+    """,
+        True,
+        True,
+        0,
+    ),
+    (
+        """
+sources:
+-   name: src
+    loader: test
+    tables:
+    -   name: test
+        config:
+            meta:
+                bar: test
+                foo: test
+    """,
+        True,
+        True,
+        0,
+    ),
+    (
+        """
+sources:
+-   name: src
+    loader: test
+    tables:
+    -   name: test
+        config:
+            meta:
+                bar: test
+    """,
+        True,
+        True,
+        1,
+    ),
+    (
+        """
+sources:
+-   name: src
+    loader: test
+    config:
+        meta:
+            bar: test
+    tables:
+    -   name: test
+    """,
+        True,
+        True,
+        1,
+    ),
+    (
+        """
+sources:
+-   name: src
+    loader: test
+    config:
+        meta:
+            foo: test
+            bar: test
+    tables:
+    -   name: test
+    """,
+        True,
+        False,
+        0,
+    ),
 )
 
 


### PR DESCRIPTION
Since [dbt 1.10](https://docs.getdbt.com/reference/source-properties?version=1.10), the `meta` property has been moved to the `config` property.

This change fixes the `check_source_has_meta_keys` hook such that it works for version >=1.10 sources while still working for legacy sources.