### PR TITLE
Fix IS NOT DISTINCT FROM false positive in check_script_has_no_table_name

### DIFF
--- a/dbt_checkpoint/check_script_has_no_table_name.py
+++ b/dbt_checkpoint/check_script_has_no_table_name.py
@@ -84,7 +84,7 @@ def has_table_name(
     is_distinct_context = False
 
     for i, (prev, cur, nxt) in enumerate(prev_cur_next_iter(sql_split)):
-        # Track "IS DISTINCT FROM" expressions
+        # Track "IS DISTINCT FROM" and "IS NOT DISTINCT FROM" expressions
         if (
             prev
             and prev.lower() == "is"
@@ -92,6 +92,17 @@ def has_table_name(
             and cur.lower() == "distinct"
             and nxt
             and nxt.lower() == "from"
+        ):
+            is_distinct_context = True
+        elif (
+            prev
+            and prev.lower() == "not"
+            and cur
+            and cur.lower() == "distinct"
+            and nxt
+            and nxt.lower() == "from"
+            and i >= 2
+            and sql_split[i - 2].lower() == "is"
         ):
             is_distinct_context = True
         elif is_distinct_context and prev and prev.lower() == "from":

--- a/tests/unit/test_check_script_has_no_table_name.py
+++ b/tests/unit/test_check_script_has_no_table_name.py
@@ -398,6 +398,48 @@ select * from unioned
     ),
     (
         """
+    SELECT *
+    FROM {{ ref('my_table') }} as main
+    JOIN {{ ref('helper_table') }} as helper
+      ON main.id = helper.id
+    WHERE main.status IS NOT DISTINCT FROM helper.status
+    """,
+        [],
+        True,
+        True,
+        0,
+        {},
+    ),
+    (
+        """
+    SELECT
+        CASE
+            WHEN column_a IS NOT DISTINCT FROM column_b THEN 'Same'
+            ELSE 'Different'
+        END AS comparison
+    FROM {{ ref('model') }}
+    """,
+        [],
+        True,
+        True,
+        0,
+        {},
+    ),
+    (
+        """
+    SELECT *
+    FROM {{ ref('model') }}
+    WHERE col_a IS DISTINCT FROM col_b
+      AND col_c IS NOT DISTINCT FROM col_d
+    """,
+        [],
+        True,
+        True,
+        0,
+        {},
+    ),
+    (
+        """
     SELECT
         value
     FROM {{ ref('model') }}
@@ -580,6 +622,20 @@ def test_context_aware_parsing():
     sql = "SELECT * FROM table WHERE col IS DISTINCT FROM NULL"
     _, tables = has_table_name(sql, "test.sql")
     assert tables == {"table"}  # Only 'table' should be detected, not 'NULL'
+
+    # Test IS NOT DISTINCT FROM tracking (issue #339)
+    sql = "SELECT * FROM table WHERE col IS NOT DISTINCT FROM other_col"
+    _, tables = has_table_name(sql, "test.sql")
+    assert tables == {"table"}  # Only 'table', not 'other_col'
+
+    # Test IS NOT DISTINCT FROM across two tables (the #339 repro shape)
+    sql = """
+    SELECT * FROM source_a
+    JOIN source_b ON source_a.id = source_b.id
+    WHERE source_a.status IS NOT DISTINCT FROM source_b.status
+    """
+    _, tables = has_table_name(sql, "test.sql")
+    assert tables == {"source_a", "source_b"}  # Not 'source_b.status'
 
     # Test function context tracking with EXTRACT
     sql = "SELECT EXTRACT(YEAR FROM date_field) FROM table"


### PR DESCRIPTION
## What

Fix `check-script-has-no-table-name` flagging the column after `FROM` in `IS NOT DISTINCT FROM` expressions as a hardcoded table.

Repro from #339:

```sql
SELECT *
FROM {{ ref('my_table') }} as main
JOIN {{ ref('helper_table') }} as helper
  ON main.id = helper.id
WHERE main.status IS NOT DISTINCT FROM helper.status
```

Before: hook errors with `does not use source() or ref() macros for tables: - helper.status`. After: passes.

## Why

The existing `IS DISTINCT FROM` detection in `has_table_name` uses a three-token sliding window (`prev="is"`, `cur="distinct"`, `nxt="from"`). The four-token `IS NOT DISTINCT FROM` doesn't match because `prev` is `not` when `cur` hits `distinct`.

## How

One additional `elif` branch in the existing detection block. Recognises the four-token form by checking `prev="not"`, `cur="distinct"`, `nxt="from"`, and `sql_split[i-2]="is"`. The existing exit branch (`is_distinct_context and prev=="from"`) already handles state reset once we step past the trailing FROM, so no other plumbing changes.

## Tests

Three new parametrised cases plus a `test_context_aware_parsing` assertion:

- The exact SQL from #339 (WHERE with two refs)
- `IS NOT DISTINCT FROM` inside a CASE expression
- Mixed `IS DISTINCT FROM` and `IS NOT DISTINCT FROM` in a single query

All existing tests still pass (610 in full suite, 70 in the targeted file).

Closes #339