### PR TITLE
Fix false positive on JOIN LATERAL by adding "lateral" to ALLOWED_FROM_CONTEXTS

### DIFF
--- a/dbt_checkpoint/check_script_has_no_table_name.py
+++ b/dbt_checkpoint/check_script_has_no_table_name.py
@@ -3,19 +3,16 @@ import os
 import re
 import time
 from pathlib import Path
-from typing import Generator
-from typing import List
-from typing import Optional
-from typing import Sequence
-from typing import Set
-from typing import Tuple
+from typing import Generator, Optional, Sequence, Set, Tuple, List
 
 from dbt_checkpoint.tracking import dbtCheckpointTracking
-from dbt_checkpoint.utils import add_default_args
-from dbt_checkpoint.utils import get_dbt_manifest
-from dbt_checkpoint.utils import JsonOpenError
-from dbt_checkpoint.utils import red
-from dbt_checkpoint.utils import yellow
+from dbt_checkpoint.utils import (
+    JsonOpenError,
+    add_default_args,
+    get_dbt_manifest,
+    red,
+    yellow,
+)
 
 REGEX_COMMENTS = r"(?<=(\/\*|\{#))((.|[\r\n])+?)(?=(\*+\/|#\}))|[ \t]*--.*"
 REGEX_SPLIT = r"[\s]+"

--- a/dbt_checkpoint/check_script_has_no_table_name.py
+++ b/dbt_checkpoint/check_script_has_no_table_name.py
@@ -3,16 +3,19 @@ import os
 import re
 import time
 from pathlib import Path
-from typing import Generator, Optional, Sequence, Set, Tuple, List
+from typing import Generator
+from typing import List
+from typing import Optional
+from typing import Sequence
+from typing import Set
+from typing import Tuple
 
 from dbt_checkpoint.tracking import dbtCheckpointTracking
-from dbt_checkpoint.utils import (
-    JsonOpenError,
-    add_default_args,
-    get_dbt_manifest,
-    red,
-    yellow,
-)
+from dbt_checkpoint.utils import add_default_args
+from dbt_checkpoint.utils import get_dbt_manifest
+from dbt_checkpoint.utils import JsonOpenError
+from dbt_checkpoint.utils import red
+from dbt_checkpoint.utils import yellow
 
 REGEX_COMMENTS = r"(?<=(\/\*|\{#))((.|[\r\n])+?)(?=(\*+\/|#\}))|[ \t]*--.*"
 REGEX_SPLIT = r"[\s]+"
@@ -22,7 +25,7 @@ REGEX_BRACES = r"([\{\}])"  # pragma: no mutate
 
 # Add these new constants with type annotations
 COMMON_SQL_FUNCTIONS: List[str] = ["extract", "substring", "trim", "unnest", "filter"]
-ALLOWED_FROM_CONTEXTS: List[str] = ["distinct", "position", "unnest"]
+ALLOWED_FROM_CONTEXTS: List[str] = ["distinct", "position", "unnest", "lateral"]
 REGEX_STRING_LITERALS = r"'(?:[^']|'')*'"
 
 

--- a/tests/unit/test_check_script_has_no_table_name.py
+++ b/tests/unit/test_check_script_has_no_table_name.py
@@ -466,6 +466,40 @@ select * from unioned
         1,
         {"actual_table"},
     ),
+    (
+        """
+    WITH raw AS (
+        SELECT * FROM {{ ref('source_model') }}
+    )
+    SELECT
+        raw.id,
+        f.value::number AS item
+    FROM raw
+    INNER JOIN
+        LATERAL FLATTEN(input => raw.payload:items) AS f
+    """,
+        [],
+        True,
+        True,
+        0,
+        {},
+    ),
+    (
+        """
+    WITH source AS (
+        SELECT * FROM {{ source('aws_lambda', 'purchase_orders') }}
+    )
+    SELECT *
+    FROM source
+    CROSS JOIN LATERAL FLATTEN(input => source.line_items) AS f
+    JOIN actual_table ON actual_table.id = f.value:id
+    """,
+        [],
+        True,
+        True,
+        1,
+        {"actual_table"},
+    ),
 )
 
 
@@ -607,3 +641,31 @@ def test_context_aware_parsing():
     """
     _, tables = has_table_name(sql, "test.sql")
     assert tables == {"table", "valid_table"}  # Only actual tables should be detected
+
+    # Test JOIN LATERAL flatten (Snowflake/Postgres/BigQuery/Databricks)
+    sql = """
+    SELECT f.value
+    FROM {{ ref('model') }} model
+    INNER JOIN LATERAL FLATTEN(input => model.payload) AS f
+    """
+    _, tables = has_table_name(sql, "test.sql")
+    assert tables == set()  # 'lateral' should not be flagged
+
+    # Test , LATERAL flatten form (existing behaviour, locked in)
+    sql = """
+    SELECT f.value
+    FROM {{ ref('model') }} model,
+         LATERAL FLATTEN(input => model.payload) AS f
+    """
+    _, tables = has_table_name(sql, "test.sql")
+    assert tables == set()
+
+    # Real hardcoded ref after LATERAL is still detected
+    sql = """
+    SELECT *
+    FROM {{ ref('model') }} model
+    CROSS JOIN LATERAL FLATTEN(input => model.payload) AS f
+    JOIN actual_table ON actual_table.id = f.value:id
+    """
+    _, tables = has_table_name(sql, "test.sql")
+    assert tables == {"actual_table"}


### PR DESCRIPTION
## Summary

Adds `"lateral"` to `ALLOWED_FROM_CONTEXTS` so that valid `JOIN LATERAL <table_function>` syntax (Snowflake, Postgres, BigQuery, Databricks) doesn't trigger a false positive in `check-script-has-no-table-name`.

Closes #352

## Background

`LATERAL` is a SQL keyword used to introduce a correlated subquery or table function — it is not a table name. Two common forms exist:

    -- Form A: explicit JOIN LATERAL
    from t inner join lateral flatten(input => t.col) as f

    -- Form B: comma + LATERAL (Snowflake idiom)
    from t, lateral flatten(input => t.col) as f

Form B already passes the hook, but only by coincidence: the walker sees `from` → `t,` (comma stripped to `t`, treated as a table/CTE), and the next token after the comma has `prev=t`, so the `from`/`join` rule doesn't fire on `lateral`. There's an existing test that locks in this behaviour (added in #11 back in 2021).

Form A — `inner join lateral ...` — fails today, because the walker sees `prev=join`, `cur=lateral` and adds `lateral` to the detected-tables set. The user gets:

    does not use source() or ref() macros for tables:
     - lateral

## Fix

One-line change to add `"lateral"` to the existing allow-list. This mirrors how `unnest` is already handled (BigQuery's analogue of `LATERAL`).

    ALLOWED_FROM_CONTEXTS: List[str] = ["distinct", "position", "unnest", "lateral"]

## Test plan

- [x] Added a new test case covering `INNER JOIN LATERAL FLATTEN(...) AS u` (the failing case from #352).
- [x] Added a new test case to verify a *real* hardcoded ref (`actual_table`) following a `LATERAL FLATTEN` is still detected — confirms the fix doesn't weaken the actual check.
- [x] Added unit-level coverage in `test_context_aware_parsing` for the `JOIN LATERAL`, `, LATERAL`, and "real ref after LATERAL" scenarios.
- [x] Existing tests still pass — no regressions.

## Notes

The maintainer noted in #291 that a proper SQL parser (e.g. `sqlglot`) would be the long-term solution. This PR is a small, targeted fix in the spirit of the existing context-aware checks; it doesn't preclude that larger refactor.