### PR TITLE
Fix TABLE(), JSON_TABLE() and empty-string-literal false positives (#…

### DIFF
--- a/dbt_checkpoint/check_script_has_no_table_name.py
+++ b/dbt_checkpoint/check_script_has_no_table_name.py
@@ -16,12 +16,25 @@ from dbt_checkpoint.utils import (
 
 REGEX_COMMENTS = r"(?<=(\/\*|\{#))((.|[\r\n])+?)(?=(\*+\/|#\}))|[ \t]*--.*"
 REGEX_SPLIT = r"[\s]+"
-IGNORE_WORDS = ["", "(", "{{", "{", "null"]  # pragma: no mutate
+IGNORE_WORDS = ["", "(", "{{", "{", "null", "''"]  # pragma: no mutate
 REGEX_PARENTHESIS = r"([\(\)])"  # pragma: no mutate
 REGEX_BRACES = r"([\{\}])"  # pragma: no mutate
 
 # Add these new constants with type annotations
-COMMON_SQL_FUNCTIONS: List[str] = ["extract", "substring", "trim", "unnest", "filter"]
+# `table` and `json_table` are SQL/2016 table-valued functions
+# (SQL Server, Oracle, DB2, MySQL 8+, MariaDB) — `JOIN TABLE(my_fn())`
+# and `JOIN JSON_TABLE(payload, '$.items[*]' COLUMNS (...))`. Listing them
+# here as functions (rather than ALLOWED_FROM_CONTEXTS) keeps `FROM table`
+# without parens still flagged as a real table reference.
+COMMON_SQL_FUNCTIONS: List[str] = [
+    "extract",
+    "substring",
+    "trim",
+    "unnest",
+    "filter",
+    "table",
+    "json_table",
+]
 ALLOWED_FROM_CONTEXTS: List[str] = ["distinct", "position", "unnest", "lateral"]
 REGEX_STRING_LITERALS = r"'(?:[^']|'')*'"
 

--- a/tests/unit/test_check_script_has_no_table_name.py
+++ b/tests/unit/test_check_script_has_no_table_name.py
@@ -542,6 +542,60 @@ select * from unioned
         1,
         {"actual_table"},
     ),
+    # issue #346: TABLE() table-valued function (SQL Server / Oracle / DB2)
+    (
+        """
+    SELECT *
+    FROM {{ ref('events') }}
+    JOIN TABLE(my_function()) AS t ON t.id = events.id
+    """,
+        [],
+        True,
+        True,
+        0,
+        {},
+    ),
+    # issue #346: JSON_TABLE (SQL/2016, MySQL 8+, SQL Server 2022+, Oracle)
+    (
+        """
+    SELECT j.id, j.name
+    FROM {{ ref('docs') }}
+    CROSS JOIN JSON_TABLE(payload, '$.items[*]' COLUMNS (id INT, name VARCHAR(50))) AS j
+    """,
+        [],
+        True,
+        True,
+        0,
+        {},
+    ),
+    # issue #346: TABLE() must not mask a real bare `actual_table` join
+    (
+        """
+    SELECT *
+    FROM {{ ref('events') }}
+    JOIN TABLE(my_function()) AS t ON t.id = events.id
+    JOIN actual_table ON actual_table.id = events.actual_id
+    """,
+        [],
+        True,
+        True,
+        1,
+        {"actual_table"},
+    ),
+    # Phantom-table from string literal: `from '...'` collapses to `from ''`
+    # which previously got added as a table name (the empty-quote token was
+    # not in IGNORE_WORDS).
+    (
+        """
+    SELECT 'from somewhere' AS note, *
+    FROM {{ ref('model') }}
+    """,
+        [],
+        True,
+        True,
+        0,
+        {},
+    ),
 )
 
 
@@ -725,3 +779,48 @@ def test_context_aware_parsing():
     """
     _, tables = has_table_name(sql, "test.sql")
     assert tables == {"actual_table"}
+
+    # issue #346: TABLE() table-valued function (SQL Server / Oracle / DB2)
+    sql = """
+    SELECT *
+    FROM {{ ref('events') }}
+    JOIN TABLE(my_function()) AS t ON t.id = events.id
+    """
+    _, tables = has_table_name(sql, "test.sql")
+    assert tables == set()  # 'table' should not be flagged
+
+    # issue #346: JSON_TABLE (SQL/2016, MySQL 8+, SQL Server 2022+, Oracle)
+    sql = """
+    SELECT j.id
+    FROM {{ ref('docs') }}
+    CROSS JOIN JSON_TABLE(payload, '$.items[*]' COLUMNS (id INT)) AS j
+    """
+    _, tables = has_table_name(sql, "test.sql")
+    assert tables == set()  # 'json_table' should not be flagged
+
+    # Bare `FROM table` (no parens) is still flagged — TABLE in
+    # COMMON_SQL_FUNCTIONS only triggers when followed by `(`, so a real
+    # (quoted-keyword) table named `table` is not silently masked.
+    sql = "SELECT * FROM table"
+    _, tables = has_table_name(sql, "test.sql")
+    assert tables == {"table"}
+
+    # Real hardcoded join after a TABLE() call is still detected.
+    sql = """
+    SELECT *
+    FROM {{ ref('events') }}
+    JOIN TABLE(my_function()) AS t ON t.id = events.id
+    JOIN actual_table ON actual_table.id = events.actual_id
+    """
+    _, tables = has_table_name(sql, "test.sql")
+    assert tables == {"actual_table"}
+
+    # Phantom-table from string literal: `from '...'` collapses to `from ''`,
+    # which used to get added as a table because the empty-quote token wasn't
+    # in IGNORE_WORDS.
+    sql = """
+    SELECT 'from somewhere' AS note, *
+    FROM {{ ref('model') }}
+    """
+    _, tables = has_table_name(sql, "test.sql")
+    assert tables == set()


### PR DESCRIPTION
Closes #346.

The reproducer in the issue (`from 'your table' join unnest('your nested field')`) actually exercises three separate paths through `check_script_has_no_table_name`, and only one of them (UNNEST) was fixed by #291. After today's #353 (LATERAL), two are left.

`JOIN TABLE(my_function()) AS t` flags `table` as a hardcoded table. `TABLE(...)` is the SQL/2016 standard syntax for invoking a table-valued function inline, used in Oracle and DB2.

`CROSS JOIN JSON_TABLE(payload, '$.items[*]' COLUMNS (id INT)) AS j` flags `json_table`. Also SQL/2016, supported in Oracle 12c R2+, MySQL 8+, MariaDB 10.6+, and DB2 11.5+.

The third path is a phantom-table bug: `replace_string_literals` collapses `'foo'` to `''`, but `''` was not in `IGNORE_WORDS`. Any quoted literal that lands right after `FROM` or `JOIN` (the issue's `from 'your table'` is the obvious case, but it also shows up when whitespace breaks oddly around a SELECT-list literal) gets recorded as a phantom table.

The fix is two small changes:

`"table"` and `"json_table"` go into `COMMON_SQL_FUNCTIONS`, so the existing inside-function flag fires when they're followed by `(` and the FROM/JOIN extraction skips them on that iteration. Putting them here rather than `ALLOWED_FROM_CONTEXTS` is deliberate: a real bare `FROM table` (no parens, typically a quoted reserved-word table name) is still flagged. There's a regression test in `test_context_aware_parsing` that pins this.

`"''"` goes into `IGNORE_WORDS`.

Tests:
- 4 new parametrised cases in `TESTS` (TABLE single, JSON_TABLE, TABLE plus a real bare-table mixed, string-literal-after-FROM)
- 5 new assertions in `test_context_aware_parsing` covering the same plus the bare-`FROM table` regression guard
- `pytest tests/unit/test_check_script_has_no_table_name.py`: 82 pass (was 64)
- Full suite: 624 pass. The one failure is `test_unify_column_description.py`, a Windows-locale unicode issue from #342 that fails on `main` too, unrelated to this change.

Commit signed (ED25519).