### PR TITLE
Fix check-source-has-freshness to support config: block (dbt 1.9+)

### DIFF
--- a/dbt_checkpoint/check_source_has_freshness.py
+++ b/dbt_checkpoint/check_source_has_freshness.py
@@ -27,7 +27,14 @@ def has_freshness(
     for schema in schemas:
         source = schema.source_schema
         table = schema.table_schema
-        merged = {**(source.get("freshness") or {}), **(table.get("freshness") or {})}
+        source_config = source.get("config") or {}
+        table_config = table.get("config") or {}
+        merged = {
+            **(source_config.get("freshness") or {}),
+            **(source.get("freshness") or {}),
+            **(table_config.get("freshness") or {}),
+            **(table.get("freshness") or {}),
+        }
         # if filter is present, remove it because it's not a dictionary like
         # warn_after or error_after
         if "filter" in merged.keys():
@@ -37,7 +44,12 @@ def has_freshness(
             for key, value in merged.items()
             if set(value.keys()) == {"count", "period"}
         }
-        loaded = table.get("loaded_at_field") or source.get("loaded_at_field")
+        loaded = (
+            table.get("loaded_at_field")
+            or table_config.get("loaded_at_field")
+            or source.get("loaded_at_field")
+            or source_config.get("loaded_at_field")
+        )
         if not loaded:
             status_code = 1
             print(

--- a/tests/unit/test_check_source_has_freshness.py
+++ b/tests/unit/test_check_source_has_freshness.py
@@ -161,6 +161,48 @@ sources:
         False,
         0,
     ),
+    # freshness and loaded_at_field inside config: at table level (dbt 1.9+ preferred form)
+    (
+        """
+sources:
+-   name: test
+    tables:
+    -   name: with_description
+        config:
+            loaded_at_field: aa
+            freshness:
+                warn_after:
+                    count: 12
+                    period: hour
+                error_after:
+                    count: 24
+                    period: hour
+    """,
+        True,
+        True,
+        0,
+    ),
+    # freshness and loaded_at_field inside config: at source level (dbt 1.9+ preferred form)
+    (
+        """
+sources:
+-   name: test
+    config:
+        loaded_at_field: aa
+        freshness:
+            warn_after:
+                count: 12
+                period: hour
+            error_after:
+                count: 24
+                period: hour
+    tables:
+    -   name: with_description
+    """,
+        True,
+        True,
+        0,
+    ),
 )
 
 


### PR DESCRIPTION
Fix for https://github.com/dbt-checkpoint/dbt-checkpoint/issues/357

dbt 1.9+ emits `PropertyMovedToConfigDeprecation` warnings when freshness and `loaded_at_field` are defined at the top level of a source or table. Moving them into a config: block silences the warnings, but previously caused `check-source-has-freshness` to fail with a false negative.

This fix makes the hook also inspect `config.freshness` and `config.loaded_at_field` at both source and table level, consistent with how dbt resolves these properties.