### PR TITLE
fix: skip TABLE(...) function calls in check-script-has-no-table-name

### DIFF
--- a/dbt_checkpoint/check_script_has_no_table_name.py
+++ b/dbt_checkpoint/check_script_has_no_table_name.py
@@ -133,6 +133,10 @@ def has_table_name(
             if cur.lower() in ALLOWED_FROM_CONTEXTS:
                 continue
 
+            # Skip TABLE(...) function calls (e.g. Snowflake GENERATOR, RESULT_SCAN)
+            if cur.lower() == "table" and nxt and nxt.startswith("("):
+                continue
+
             # Skip if in an "IS DISTINCT FROM" expression
             if is_distinct_context:
                 continue

--- a/tests/unit/test_check_script_has_no_table_name.py
+++ b/tests/unit/test_check_script_has_no_table_name.py
@@ -725,3 +725,33 @@ def test_context_aware_parsing():
     """
     _, tables = has_table_name(sql, "test.sql")
     assert tables == {"actual_table"}
+
+
+def test_table_generator_not_flagged():
+    """Test that FROM TABLE(...) is not flagged as a table reference (Snowflake syntax)."""
+    # TABLE(GENERATOR(...)) for generating rows
+    sql = """
+    SELECT SEQ4() AS id
+    FROM TABLE(GENERATOR(ROWCOUNT => 100))
+    """
+    _, tables = has_table_name(sql, "test.sql")
+    assert tables == set()
+
+    # TABLE(RESULT_SCAN(...)) for querying previous results
+    sql = """
+    SELECT * FROM TABLE(RESULT_SCAN(LAST_QUERY_ID()))
+    """
+    _, tables = has_table_name(sql, "test.sql")
+    assert tables == set()
+
+    # TABLE(GENERATOR(...)) alongside a real hardcoded table
+    sql = """
+    WITH numbers AS (
+        SELECT SEQ4() AS n
+        FROM TABLE(GENERATOR(ROWCOUNT => 1000))
+    )
+    SELECT * FROM numbers
+    JOIN real_table ON real_table.id = numbers.n
+    """
+    _, tables = has_table_name(sql, "test.sql")
+    assert tables == {"real_table"}


### PR DESCRIPTION
## Summary

`check-script-has-no-table-name` incorrectly flags Snowflake's `TABLE(...)` syntax as a raw table reference.

Common patterns that trigger the false positive:
```sql
SELECT SEQ4() AS id FROM TABLE(GENERATOR(ROWCOUNT => 100))

SELECT * FROM TABLE(RESULT_SCAN(LAST_QUERY_ID()))
```

## Fix

Check if `table` is followed by `(` to distinguish the `TABLE()` function call from an actual table named "table". A bare `FROM table` (as a table name) is still correctly detected.

## Tests

Added `test_table_generator_not_flagged` covering:
- `TABLE(GENERATOR(...))` — not flagged
- `TABLE(RESULT_SCAN(...))` — not flagged
- `TABLE(GENERATOR(...))` alongside a real hardcoded table — only the real table is flagged

All 75 existing tests continue to pass.