### PR TITLE
Add table-valued functions to COMMON_SQL_FUNCTIONS (Postgres / DuckDB / BigQuery)

### DIFF
--- a/dbt_checkpoint/check_script_has_no_table_name.py
+++ b/dbt_checkpoint/check_script_has_no_table_name.py
@@ -21,11 +21,6 @@ REGEX_PARENTHESIS = r"([\(\)])"  # pragma: no mutate
 REGEX_BRACES = r"([\{\}])"  # pragma: no mutate
 
 # Add these new constants with type annotations
-# `table` and `json_table` are SQL/2016 table-valued functions
-# (SQL Server, Oracle, DB2, MySQL 8+, MariaDB) — `JOIN TABLE(my_fn())`
-# and `JOIN JSON_TABLE(payload, '$.items[*]' COLUMNS (...))`. Listing them
-# here as functions (rather than ALLOWED_FROM_CONTEXTS) keeps `FROM table`
-# without parens still flagged as a real table reference.
 COMMON_SQL_FUNCTIONS: List[str] = [
     "extract",
     "substring",
@@ -34,6 +29,17 @@ COMMON_SQL_FUNCTIONS: List[str] = [
     "filter",
     "table",
     "json_table",
+    # Postgres: set-returning / table-valued functions used directly in FROM
+    "generate_series",
+    "jsonb_array_elements",
+    "jsonb_each",
+    "json_array_elements",
+    "regexp_split_to_table",
+    # DuckDB: file-reader functions used in FROM
+    "read_csv",
+    "read_parquet",
+    # BigQuery: federated query function used in FROM
+    "external_query",
 ]
 ALLOWED_FROM_CONTEXTS: List[str] = ["distinct", "position", "unnest", "lateral"]
 REGEX_STRING_LITERALS = r"'(?:[^']|'')*'"

--- a/tests/unit/test_check_script_has_no_table_name.py
+++ b/tests/unit/test_check_script_has_no_table_name.py
@@ -596,6 +596,88 @@ select * from unioned
         0,
         {},
     ),
+    # Postgres GENERATE_SERIES used directly in FROM is not a hardcoded table.
+    (
+        "SELECT * FROM GENERATE_SERIES(1, 100) AS s",
+        [],
+        True,
+        True,
+        0,
+        set(),
+    ),
+    # Postgres JSONB set-returning functions in FROM should not be flagged.
+    (
+        "SELECT * FROM JSONB_ARRAY_ELEMENTS('[1,2,3]'::jsonb) AS j",
+        [],
+        True,
+        True,
+        0,
+        set(),
+    ),
+    (
+        "SELECT * FROM JSONB_EACH('{\"a\":1}'::jsonb)",
+        [],
+        True,
+        True,
+        0,
+        set(),
+    ),
+    (
+        "SELECT * FROM JSON_ARRAY_ELEMENTS('[1,2]'::json)",
+        [],
+        True,
+        True,
+        0,
+        set(),
+    ),
+    # Postgres REGEXP_SPLIT_TO_TABLE used in FROM.
+    (
+        "SELECT * FROM REGEXP_SPLIT_TO_TABLE('a,b,c', ',')",
+        [],
+        True,
+        True,
+        0,
+        set(),
+    ),
+    # DuckDB file readers used in FROM.
+    (
+        "SELECT * FROM READ_CSV('data.csv')",
+        [],
+        True,
+        True,
+        0,
+        set(),
+    ),
+    (
+        "SELECT * FROM READ_PARQUET('data.parquet')",
+        [],
+        True,
+        True,
+        0,
+        set(),
+    ),
+    # BigQuery EXTERNAL_QUERY used in FROM.
+    (
+        "SELECT * FROM EXTERNAL_QUERY('proj.connection', 'SELECT 1')",
+        [],
+        True,
+        True,
+        0,
+        set(),
+    ),
+    # Mixed case: ref() plus GENERATE_SERIES, plus a hardcoded table.
+    # Only the hardcoded table should be flagged.
+    (
+        """SELECT *
+        FROM {{ ref('events') }} e
+        CROSS JOIN GENERATE_SERIES(1, 24) AS hour_of_day
+        JOIN raw.customers c ON c.id = e.customer_id""",
+        [],
+        True,
+        True,
+        1,
+        {"raw.customers"},
+    ),
 )
 
 
@@ -824,3 +906,48 @@ def test_context_aware_parsing():
     """
     _, tables = has_table_name(sql, "test.sql")
     assert tables == set()
+
+    # Postgres set-returning / table-valued functions used in FROM
+    sql = "SELECT * FROM GENERATE_SERIES(1, 100) AS s"
+    _, tables = has_table_name(sql, "test.sql")
+    assert tables == set()
+
+    sql = "SELECT * FROM JSONB_ARRAY_ELEMENTS('[1,2,3]'::jsonb) AS j"
+    _, tables = has_table_name(sql, "test.sql")
+    assert tables == set()
+
+    sql = "SELECT * FROM JSONB_EACH('{\"a\":1}'::jsonb)"
+    _, tables = has_table_name(sql, "test.sql")
+    assert tables == set()
+
+    sql = "SELECT * FROM JSON_ARRAY_ELEMENTS('[1,2]'::json)"
+    _, tables = has_table_name(sql, "test.sql")
+    assert tables == set()
+
+    sql = "SELECT * FROM REGEXP_SPLIT_TO_TABLE('a,b,c', ',')"
+    _, tables = has_table_name(sql, "test.sql")
+    assert tables == set()
+
+    # DuckDB file-reader functions used in FROM
+    sql = "SELECT * FROM READ_CSV('data.csv')"
+    _, tables = has_table_name(sql, "test.sql")
+    assert tables == set()
+
+    sql = "SELECT * FROM READ_PARQUET('data.parquet')"
+    _, tables = has_table_name(sql, "test.sql")
+    assert tables == set()
+
+    # BigQuery EXTERNAL_QUERY used in FROM
+    sql = "SELECT * FROM EXTERNAL_QUERY('proj.connection', 'SELECT 1')"
+    _, tables = has_table_name(sql, "test.sql")
+    assert tables == set()
+
+    # Mixing table-valued functions with a real hardcoded ref still flags it
+    sql = """
+    SELECT *
+    FROM {{ ref('events') }} e
+    CROSS JOIN GENERATE_SERIES(1, 24) AS hour_of_day
+    JOIN raw.customers c ON c.id = e.customer_id
+    """
+    _, tables = has_table_name(sql, "test.sql")
+    assert tables == {"raw.customers"}


### PR DESCRIPTION
Rebased version of #355 (by @Pawansingh3889) on top of #354 with merge conflict resolved.

Adds 8 more dialect-specific table-valued / set-returning functions to `COMMON_SQL_FUNCTIONS` so they are not flagged as hardcoded table names when used in `FROM`/`JOIN`:

- **Postgres**: `GENERATE_SERIES`, `JSONB_ARRAY_ELEMENTS`, `JSONB_EACH`, `JSON_ARRAY_ELEMENTS`, `REGEXP_SPLIT_TO_TABLE`
- **DuckDB**: `READ_CSV`, `READ_PARQUET`
- **BigQuery**: `EXTERNAL_QUERY`

Uses the same mechanism as `unnest`, `extract`, `table`, `json_table` (merged in #354).

Closes #355.