### PR TITLE
fix: issue triage — freshness subset check, UTF-8 encoding, and dbt 1.11 config: block support

### DIFF
--- a/dbt_checkpoint/check_model_has_meta_keys.py
+++ b/dbt_checkpoint/check_model_has_meta_keys.py
@@ -60,7 +60,12 @@ def has_meta_key(
         schema.model_name
         for schema in schemas
         if validate_keys(
-            schema.schema.get("meta", {}).keys(), meta_keys, allow_extra_keys
+            {
+                *schema.schema.get("meta", {}).keys(),
+                *schema.schema.get("config", {}).get("meta", {}).keys(),
+            },
+            meta_keys,
+            allow_extra_keys,
         )
     }
     missing = filenames.difference(in_models, in_schemas)

--- a/dbt_checkpoint/check_source_has_freshness.py
+++ b/dbt_checkpoint/check_source_has_freshness.py
@@ -56,7 +56,7 @@ def has_freshness(
                 f"{red(f'{schema.source_name}.{schema.table_name}')}: "
                 f"is missing `loaded_at_field` which is required for freshness."
             )
-        if not (freshness == required_freshness):
+        if not required_freshness.issubset(freshness):
             status_code = 1
             missing_params = required_freshness.difference(freshness)
             result = "\n- ".join(list(missing_params))  # pragma: no mutate

--- a/dbt_checkpoint/check_source_tags.py
+++ b/dbt_checkpoint/check_source_tags.py
@@ -23,8 +23,12 @@ def validate_tags(
     schemas = get_source_schemas(ymls, include_disabled=include_disabled)
 
     for schema in schemas:
-        schema_tags = set(schema.source_schema.get("tags", []))
-        table_tags = set(schema.table_schema.get("tags", []))
+        schema_tags = set(schema.source_schema.get("tags", [])) | set(
+            schema.source_schema.get("config", {}).get("tags", [])
+        )
+        table_tags = set(schema.table_schema.get("tags", [])) | set(
+            schema.table_schema.get("config", {}).get("tags", [])
+        )
         source_tags = schema_tags.union(table_tags)
         valid_tags = set(tags)
         if not source_tags.issubset(valid_tags):

--- a/dbt_checkpoint/replace_script_table_names.py
+++ b/dbt_checkpoint/replace_script_table_names.py
@@ -82,7 +82,7 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
     start_time = time.time()
     for filename in args.filenames:
         file = Path(filename)
-        sql = file.read_text()
+        sql = file.read_text(encoding="utf-8")
         status_code_file, tables = has_table_name(sql, filename)
         if status_code_file:
             status_code = status_code_file

--- a/tests/unit/test_check_model_has_meta_keys.py
+++ b/tests/unit/test_check_model_has_meta_keys.py
@@ -85,6 +85,36 @@ def test_check_model_meta_keys(
 
 
 @pytest.mark.parametrize("extension", [("yml"), ("yaml")])
+def test_check_model_meta_keys_in_config(extension, tmpdir, manifest_path_str):
+    """dbt 1.9+: meta nested inside config: block in the schema YAML should be accepted."""
+    schema_yml = """
+version: 2
+
+models:
+-   name: in_schema_meta
+    config:
+        meta:
+            foo: test
+            bar: test
+-   name: xxx
+    """
+    yml_file = tmpdir.join(f"schema.{extension}")
+    yml_file.write(schema_yml)
+    result = main(
+        argv=[
+            "in_schema_meta.sql",
+            str(yml_file),
+            "--meta-keys",
+            "foo",
+            "bar",
+            "--manifest",
+            manifest_path_str,
+        ],
+    )
+    assert result == 0
+
+
+@pytest.mark.parametrize("extension", [("yml"), ("yaml")])
 def test_check_model_meta_keys_in_changed(extension, tmpdir, manifest_path_str):
     schema_yml = """
 version: 2

--- a/tests/unit/test_check_source_has_freshness.py
+++ b/tests/unit/test_check_source_has_freshness.py
@@ -206,6 +206,36 @@ sources:
 )
 
 
+def test_check_source_has_freshness_subset(tmpdir, manifest_path_str, config_path_str):
+    """Requiring only error_after should pass when source defines both warn_after and error_after."""
+    input_schema = """
+sources:
+-   name: test
+    loaded_at_field: aa
+    freshness:
+        warn_after:
+            count: 1
+            period: day
+        error_after:
+            count: 2
+            period: day
+    tables:
+    -   name: with_description
+    """
+    input_args = [
+        "--freshness",
+        "error_after",
+        "--manifest",
+        manifest_path_str,
+        "--config",
+        config_path_str,
+        "--is_test",
+    ]
+    yml_file = tmpdir.join("schema.yml")
+    yml_file.write(input_schema)
+    assert main(argv=[str(yml_file), *input_args]) == 0
+
+
 @pytest.mark.parametrize(
     ("input_schema", "valid_manifest", "valid_config", "expected_status_code"), TESTS
 )

--- a/tests/unit/test_check_source_tags.py
+++ b/tests/unit/test_check_source_tags.py
@@ -164,6 +164,40 @@ sources:
         False,
         0,
     ),
+    # dbt 1.9+: tags inside config: at source level
+    (
+        """
+sources:
+-   name: src
+    loader: test
+    config:
+        tags:
+        -   foo
+        -   bar
+    tables:
+    -   name: test
+    """,
+        True,
+        True,
+        0,
+    ),
+    # dbt 1.9+: tags inside config: at table level
+    (
+        """
+sources:
+-   name: src
+    loader: test
+    tables:
+    -   name: test
+        config:
+            tags:
+            -   foo
+            -   bar
+    """,
+        True,
+        True,
+        0,
+    ),
 )
 
 

--- a/tests/unit/test_replace_script_table_names.py
+++ b/tests/unit/test_replace_script_table_names.py
@@ -170,6 +170,20 @@ def test_replace_script_table_names(
     assert result == output
 
 
+def test_replace_script_table_names_utf8_preserved(
+    manifest_path_str, config_path_str, tmpdir
+):
+    """Non-ASCII characters (e.g. umlauts) must survive a read-replace-write cycle."""
+    sql = "-- Ä Ö Ü ä ö ü ß\nSELECT * FROM {{ ref('replaced_model') }}\n"
+    path = tmpdir.join("model.sql")
+    path.write_text(sql, "utf-8")
+    ret = main(
+        [str(path), "--is_test", "--manifest", manifest_path_str, "--config", config_path_str]
+    )
+    assert ret == 0
+    assert path.read_text(encoding="utf-8") == sql
+
+
 def test_get_source_from_name(manifest):
     result = get_source_from_name(
         manifest, {"prod.source1.src3", "dev.source1.src3", "dev2.source1.src3"}


### PR DESCRIPTION
## Summary

Three bug fixes surfaced during issue triage.

### fix: `check-source-has-freshness` always fails when source defines more freshness params than required (#307)

The check used exact set equality (`freshness == required_freshness`). If you required only `error_after` but your source defined both `warn_after` and `error_after`, the hook would fail with an empty "missing params" list — confusing and wrong. Changed to `required_freshness.issubset(freshness)`.

### fix: `replace-script-table-names` corrupts non-ASCII characters on non-UTF-8 systems (#311)

The write path already had `encoding="utf-8"` but the read path used the platform default. On Windows this mangles umlauts and other non-ASCII characters (`ü` → `Ã¼`). Added `encoding="utf-8"` to `file.read_text()`.

### fix: `config:` block support for dbt 1.11 (#313)

dbt 1.9+ deprecates top-level source/model properties in favour of a `config:` block (`PropertyMovedToConfigDeprecation`). dbt 1.11 makes these hard errors. Two remaining hooks were not reading from `config:`:

- **`check-source-tags`**: now also reads `config.tags` at both source and table level
- **`check-model-has-meta-keys`**: now also reads `config.meta` in the schema-YAML lookup path (the manifest-node path already worked)

Both hooks continue to accept top-level placement, so no migration is required for users on dbt < 1.9.

Previously fixed as part of this same effort: freshness/loaded_at_field (#358), source meta keys (ec5b7be).

## Test plan

- [ ] `pytest tests/unit/test_check_source_has_freshness.py` — new `test_check_source_has_freshness_subset` test covers the `issubset` fix
- [ ] `pytest tests/unit/test_replace_script_table_names.py` — new `test_replace_script_table_names_utf8_preserved` covers the encoding fix
- [ ] `pytest tests/unit/test_check_source_tags.py` — two new cases for `config.tags` at source and table level
- [ ] `pytest tests/unit/test_check_model_has_meta_keys.py` — two new cases (yml/yaml) for `config.meta` in the schema YAML path
- [ ] Full suite: `pytest` — 650 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)