### PR TITLE
feat: add check-model-has-group hook

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -49,6 +49,12 @@
   entry: check-model-has-contract
   language: python
   types_or: [yaml]
+- id: check-model-has-group
+  name: Check model has group
+  description: Ensures that the model has a group defined.
+  entry: check-model-has-group
+  language: python
+  types_or: [yaml, sql]
 - id: check-model-has-constraints
   name: Check model has specific constraints
   description: Check model has constraints for specific columns

--- a/HOOKS.md
+++ b/HOOKS.md
@@ -12,6 +12,7 @@
 - [`check-model-has-constraints`](https://github.com/dbt-checkpoint/dbt-checkpoint/blob/main/HOOKS.md#check-model-has-constraints): Check the model has constraints defined.
 - [`check-model-has-generic-constraints`](https://github.com/dbt-checkpoint/dbt-checkpoint/blob/main/HOOKS.md#check-model-has-generic-constraints): Check the model has generic constraints defined.
 - [`check-model-has-contract`](https://github.com/dbt-checkpoint/dbt-checkpoint/blob/main/HOOKS.md#check-model-has-contract): Check the model has contract enabled.
+- [`check-model-has-group`](https://github.com/dbt-checkpoint/dbt-checkpoint/blob/main/HOOKS.md#check-model-has-group): Check the model has a group defined.
 - [`check-model-has-description`](https://github.com/dbt-checkpoint/dbt-checkpoint/blob/main/HOOKS.md#check-model-has-description): Check the model has description.
 - [`check-model-has-meta-keys`](https://github.com/dbt-checkpoint/dbt-checkpoint/blob/main/HOOKS.md#check-model-has-meta-keys): Check the model has keys in the meta part.
 - [`check-model-has-labels-keys`](https://github.com/dbt-checkpoint/dbt-checkpoint/blob/main/HOOKS.md#check-model-has-labels-keys): Check the model has keys in the labels part.
@@ -411,6 +412,60 @@ When you want to force developers to define model contracts.
 #### How it works
 
 It checks the generated manifest for the contract configuration.
+
+---
+
+### `check-model-has-group`
+
+Ensures that the model has a [group](https://docs.getdbt.com/docs/build/groups) defined, supporting dbt's model governance feature.
+
+#### Arguments
+
+`--manifest`: Location of `manifest.json` file. Usually `target/manifest.json`. This file contains a full representation of dbt project. **Default: `target/manifest.json`**<br/>
+`--groups`: Optional list of allowed group names. If provided, models must belong to one of these groups.<br/>
+`--exclude`: Regex pattern to exclude files.
+
+#### Example
+
+```yaml
+repos:
+  - repo: https://github.com/dbt-checkpoint/dbt-checkpoint
+    rev: v1.0.0
+    hooks:
+      - id: check-model-has-group
+```
+
+With allowed groups:
+
+```yaml
+repos:
+  - repo: https://github.com/dbt-checkpoint/dbt-checkpoint
+    rev: v1.0.0
+    hooks:
+      - id: check-model-has-group
+        args: ["--groups", "analytics", "finance", "engineering", "--"]
+```
+
+#### When to use it
+
+When you want to enforce that every model has an owner/team via dbt's [groups and access](https://docs.getdbt.com/docs/collaborate/govern/model-access) governance feature.
+
+#### Requirements
+
+| Model exists in `manifest.json` <sup id="a1">[1](#f1)</sup> | Model exists in `catalog.json` <sup id="a2">[2](#f2)</sup> |
+| :---------------------------------------------------------: | :--------------------------------------------------------: |
+|                      :white_check_mark: Yes                 |                       :x: Not needed                       |
+
+<sup id="f1">1</sup> It means that you need to run `dbt parse` before run this hook (dbt >= 1.5).<br/>
+<sup id="f2">2</sup> It means that you need to run `dbt docs generate` before run this hook.
+
+#### How it works
+
+- Hook takes all changed `yml` and `SQL` files.
+- The model name is obtained from the `SQL` file name.
+- The manifest is scanned for a model's `group` in both `config.group` and the top-level `group` field.
+- If the model does not have a group defined, the hook fails.
+- If `--groups` is provided and the model's group is not in the allowed list, the hook fails.
 
 ---
 

--- a/dbt_checkpoint/check_model_has_group.py
+++ b/dbt_checkpoint/check_model_has_group.py
@@ -1,0 +1,104 @@
+import argparse
+import os
+import time
+from typing import Any, Dict, Optional, Sequence
+
+from dbt_checkpoint.tracking import dbtCheckpointTracking
+from dbt_checkpoint.utils import (
+    JsonOpenError,
+    add_default_args,
+    get_dbt_manifest,
+    get_missing_file_paths,
+    get_model_sqls,
+    get_models,
+)
+
+
+def check_group(
+    paths: Sequence[str],
+    manifest: Dict[str, Any],
+    exclude_pattern: str,
+    groups: Optional[Sequence[str]] = None,
+    include_disabled: bool = False,
+) -> int:
+    paths = get_missing_file_paths(
+        paths, manifest, extensions=[".sql"], exclude_pattern=exclude_pattern
+    )
+
+    status_code = 0
+    sqls = get_model_sqls(paths, manifest, include_disabled)
+    filenames = set(sqls.keys())
+
+    # get manifest nodes that pre-commit found as changed
+    models = get_models(manifest, filenames, include_disabled=include_disabled)
+
+    for model in models:
+        model_group = model.node.get("config", {}).get("group") or model.node.get(
+            "group"
+        )
+
+        if not model_group:
+            status_code = 1
+            print(
+                f"{model.node.get('original_file_path', model.filename)}: "
+                f"does not have a group defined.",
+            )
+        elif groups and model_group not in groups:
+            status_code = 1
+            print(
+                f"{model.node.get('original_file_path', model.filename)}: "
+                f"has group '{model_group}' which is not in allowed groups: {groups}.",
+            )
+
+    return status_code
+
+
+def main(argv: Optional[Sequence[str]] = None) -> int:
+    parser = argparse.ArgumentParser()
+    add_default_args(parser)
+
+    parser.add_argument(
+        "--groups",
+        nargs="+",
+        required=False,
+        default=None,
+        help="Optional list of allowed group names.",
+    )
+
+    args = parser.parse_args(argv)
+
+    try:
+        manifest = get_dbt_manifest(args)
+    except JsonOpenError as e:
+        print(f"Unable to load manifest file ({e})")
+        return 1
+
+    start_time = time.time()
+    status_code = check_group(
+        paths=args.filenames,
+        manifest=manifest,
+        exclude_pattern=args.exclude,
+        groups=args.groups,
+        include_disabled=args.include_disabled,
+    )
+    end_time = time.time()
+    script_args = vars(args)
+
+    tracker = dbtCheckpointTracking(script_args=script_args)
+    tracker.track_hook_event(
+        event_name="Hook Executed",
+        manifest=manifest,
+        event_properties={
+            "hook_name": os.path.basename(__file__),
+            "description": "Check model has group",
+            "status": status_code,
+            "execution_time": end_time - start_time,
+            "is_pytest": script_args.get("is_test"),
+        },
+    )
+
+    return status_code
+
+
+if __name__ == "__main__":
+    exit(main())

--- a/setup.cfg
+++ b/setup.cfg
@@ -38,6 +38,7 @@ console_scripts =
     check-model-has-all-columns = dbt_checkpoint.check_model_has_all_columns:main
     check-model-has-columns-with-types = dbt_checkpoint.check_model_has_columns_with_types:main
     check-model-has-contract = dbt_checkpoint.check_model_has_contract:main
+    check-model-has-group = dbt_checkpoint.check_model_has_group:main
     check-model-has-constraints = dbt_checkpoint.check_model_has_constraints:main
     check-model-has-generic-constraints = dbt_checkpoint.check_model_has_generic_constraints:main
     check-model-has-description = dbt_checkpoint.check_model_has_description:main

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -374,6 +374,26 @@ MANIFEST = {
             "path": "aa/bb/with_no_contract.sql",
             "root_path": "/path/to/aa",
         },
+        "model.with_group": {
+            "patch_path": "project://bb/with_group.yml",
+            "path": "aa/bb/with_group.sql",
+            "root_path": "/path/to/aa",
+            "config": {"group": "analytics", "materialized": "view"},
+            "group": "analytics",
+        },
+        "model.with_no_group": {
+            "patch_path": "project://bb/with_no_group.yml",
+            "path": "aa/bb/with_no_group.sql",
+            "root_path": "/path/to/aa",
+            "config": {"materialized": "view"},
+        },
+        "model.with_invalid_group": {
+            "patch_path": "project://bb/with_invalid_group.yml",
+            "path": "aa/bb/with_invalid_group.sql",
+            "root_path": "/path/to/aa",
+            "config": {"group": "unknown_team", "materialized": "view"},
+            "group": "unknown_team",
+        },
         "model.with_no_constraints": {
             "patch_path": "project://bb/with_no_constraints.yml",
             "path": "aa/bb/with_no_constraints.sql",

--- a/tests/unit/test_check_model_has_group.py
+++ b/tests/unit/test_check_model_has_group.py
@@ -1,0 +1,33 @@
+import pytest
+
+from dbt_checkpoint.check_model_has_group import main
+
+
+TESTS = (
+    (["aa/bb/with_group.sql"], None, 0),
+    (["aa/bb/with_no_group.sql"], None, 1),
+    (["aa/bb/with_group.sql"], ["analytics", "finance"], 0),
+    (["aa/bb/with_invalid_group.sql"], ["analytics", "finance"], 1),
+)
+
+
+@pytest.mark.parametrize(
+    (
+        "input_args",
+        "allowed_groups",
+        "expected_status_code",
+    ),
+    TESTS,
+)
+def test_check_model_has_group(
+    input_args,
+    allowed_groups,
+    expected_status_code,
+    manifest_path_str,
+):
+    if allowed_groups:
+        input_args.extend(["--groups"] + allowed_groups)
+    input_args.extend(["--manifest", manifest_path_str])
+
+    status_code = main(input_args)
+    assert status_code == expected_status_code

--- a/tests/unit/test_check_model_has_group.py
+++ b/tests/unit/test_check_model_has_group.py
@@ -4,16 +4,18 @@ from dbt_checkpoint.check_model_has_group import main
 
 
 TESTS = (
-    (["aa/bb/with_group.sql"], None, 0),
-    (["aa/bb/with_no_group.sql"], None, 1),
-    (["aa/bb/with_group.sql"], ["analytics", "finance"], 0),
-    (["aa/bb/with_invalid_group.sql"], ["analytics", "finance"], 1),
+    (["aa/bb/with_group.sql"], True, None, 0),
+    (["aa/bb/with_no_group.sql"], True, None, 1),
+    (["aa/bb/with_group.sql"], True, ["analytics", "finance"], 0),
+    (["aa/bb/with_invalid_group.sql"], True, ["analytics", "finance"], 1),
+    (["aa/bb/with_group.sql"], False, None, 1),
 )
 
 
 @pytest.mark.parametrize(
     (
         "input_args",
+        "valid_manifest",
         "allowed_groups",
         "expected_status_code",
     ),
@@ -21,13 +23,17 @@ TESTS = (
 )
 def test_check_model_has_group(
     input_args,
+    valid_manifest,
     allowed_groups,
     expected_status_code,
     manifest_path_str,
 ):
     if allowed_groups:
         input_args.extend(["--groups"] + allowed_groups)
-    input_args.extend(["--manifest", manifest_path_str])
+    if valid_manifest:
+        input_args.extend(["--manifest", manifest_path_str])
+    else:
+        input_args.extend(["--manifest", "/tmp/nonexistent/manifest.json"])
 
     status_code = main(input_args)
     assert status_code == expected_status_code


### PR DESCRIPTION
## Summary

- Adds a new `check-model-has-group` pre-commit hook that ensures dbt models have a `group` defined, supporting [dbt's model governance feature](https://docs.getdbt.com/docs/build/groups).
- Optionally accepts `--groups` to restrict models to a set of allowed group names.
- Includes unit tests and manifest fixtures.

## Usage

```yaml
repos:
  - repo: https://github.com/dbt-checkpoint/dbt-checkpoint
    rev: v2.0.10
    hooks:
      - id: check-model-has-group
```

With allowed groups:

```yaml
repos:
  - repo: https://github.com/dbt-checkpoint/dbt-checkpoint
    rev: v2.0.10
    hooks:
      - id: check-model-has-group
        args: ["--groups", "analytics", "finance", "engineering", "--"]
```

## Motivation

Closes #298

dbt has released [groups](https://docs.getdbt.com/docs/build/groups) as a governance feature. This hook ensures all models have a group assigned, which is essential for enforcing ownership and access control in multi-team dbt projects.

## Test plan

- [x] Unit tests pass (`pytest tests/unit/test_check_model_has_group.py`)
- [x] Tests cover: model with group (pass), model without group (fail), model with valid group from allowed list (pass), model with invalid group not in allowed list (fail)