### PR TITLE
fix: replace recursive glob with direct path lookup in file discovery

### DIFF
--- a/dbt_checkpoint/utils.py
+++ b/dbt_checkpoint/utils.py
@@ -15,7 +15,6 @@ from typing import Set
 from typing import Text
 from typing import Union
 
-
 from yaml import safe_load
 
 DEFAULT_MANIFEST_PATH = "target/manifest.json"
@@ -704,6 +703,10 @@ def add_related_sqls(
     yml_path_parts.pop(0)
     dbt_patch_path = "/".join(yml_path_parts)
 
+    prefix = ""
+    if dbt_patch_path and yml_path.endswith(dbt_patch_path):
+        prefix = yml_path[: -len(dbt_patch_path)]
+
     for key, node in nodes.items():
         if (
             not include_ephemeral
@@ -713,10 +716,8 @@ def add_related_sqls(
 
         if node.get("patch_path") and dbt_patch_path in node.get("patch_path"):
             if ".sql" in node.get("original_file_path", "").lower():
-                for related_sql_file in _discover_sql_files(node):
-                    sql_as_string = related_sql_file.as_posix()
-                    if "target/" not in sql_as_string.lower():
-                        paths_with_missing.add(sql_as_string)
+                for related_sql_file in _discover_sql_files(node, prefix):
+                    paths_with_missing.add(related_sql_file.as_posix())
 
 
 def add_related_ymls(
@@ -733,6 +734,12 @@ def add_related_ymls(
             continue
 
         if node.get("path") and (node.get("path") in sql_path):
+            node_path = node.get("path")
+            prefix = ""
+            idx = sql_path.find(node_path)
+            if idx > 0:
+                prefix = sql_path[:idx]
+
             patch_path = node.get("patch_path", None)
             if patch_path:
                 # Original patch_path has 'project\\path\to\yml.yml'
@@ -741,18 +748,18 @@ def add_related_ymls(
                 clean_patch_path = patch_path.relative_to(
                     *patch_path.parts[:1]
                 ).as_posix()
-                for related_yml_file in _discover_prop_files(clean_patch_path):
-                    yml_as_string = related_yml_file.as_posix()
-                    if "target/" not in yml_as_string.lower():
-                        paths_with_missing.add(yml_as_string)
+                for related_yml_file in _discover_prop_files(clean_patch_path, prefix):
+                    paths_with_missing.add(related_yml_file.as_posix())
 
 
-def _discover_sql_files(node):  # type: ignore
-    return Path().glob(f"**/{node.get('original_file_path')}")
+def _discover_sql_files(node, prefix=""):  # type: ignore
+    path = Path(prefix + node.get("original_file_path", ""))
+    return [path] if path.exists() else []
 
 
-def _discover_prop_files(model_path):  # type: ignore
-    return Path().glob(f"**/{model_path}")
+def _discover_prop_files(model_path, prefix=""):  # type: ignore
+    path = Path(prefix + model_path)
+    return [path] if path.exists() else []
 
 
 def get_missing_file_paths(

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -5,25 +5,25 @@ from unittest.mock import patch
 
 import pytest
 
-from dbt_checkpoint.utils import (
-    CalledProcessError,
-    CompilationException,
-    MacroSchema,
-    Model,
-    ModelSchema,
-    SourceSchema,
-    check_yml_version,
-    cmd_output,
-    extend_dbt_project_dir_flag,
-    get_dbt_catalog,
-    get_dbt_manifest,
-    get_filenames,
-    get_macro_schemas,
-    get_missing_file_paths,
-    get_model_schemas,
-    obj_in_deps,
-    paths_to_dbt_models,
-)
+from dbt_checkpoint.utils import _discover_prop_files
+from dbt_checkpoint.utils import _discover_sql_files
+from dbt_checkpoint.utils import CalledProcessError
+from dbt_checkpoint.utils import check_yml_version
+from dbt_checkpoint.utils import cmd_output
+from dbt_checkpoint.utils import CompilationException
+from dbt_checkpoint.utils import extend_dbt_project_dir_flag
+from dbt_checkpoint.utils import get_dbt_catalog
+from dbt_checkpoint.utils import get_dbt_manifest
+from dbt_checkpoint.utils import get_filenames
+from dbt_checkpoint.utils import get_macro_schemas
+from dbt_checkpoint.utils import get_missing_file_paths
+from dbt_checkpoint.utils import get_model_schemas
+from dbt_checkpoint.utils import MacroSchema
+from dbt_checkpoint.utils import Model
+from dbt_checkpoint.utils import ModelSchema
+from dbt_checkpoint.utils import obj_in_deps
+from dbt_checkpoint.utils import paths_to_dbt_models
+from dbt_checkpoint.utils import SourceSchema
 
 
 def test_cmd_output_error():
@@ -225,6 +225,66 @@ def test_extend_dbt_cmd_flags_with_project_dir():
     result = extend_dbt_project_dir_flag(cmd, cmd_flags, dbt_project_dir)
 
     assert result == expected_result
+
+
+def test_discover_sql_files_direct_path(tmpdir, monkeypatch):
+    """_discover_sql_files finds file by direct path, not recursive glob."""
+    monkeypatch.chdir(tmpdir)
+    sql_dir = Path(str(tmpdir)) / "models" / "staging"
+    sql_dir.mkdir(parents=True)
+    (sql_dir / "orders.sql").write_text("SELECT 1")
+
+    # Decoy in .venv that the old glob would find
+    venv_dir = Path(str(tmpdir)) / ".venv" / "lib" / "models" / "staging"
+    venv_dir.mkdir(parents=True)
+    (venv_dir / "orders.sql").write_text("SELECT 1")
+
+    node = {"original_file_path": "models/staging/orders.sql"}
+    result = list(_discover_sql_files(node))
+    assert len(result) == 1
+    assert result[0] == Path("models/staging/orders.sql")
+
+
+def test_discover_sql_files_missing(tmpdir, monkeypatch):
+    """_discover_sql_files returns empty list for nonexistent file."""
+    monkeypatch.chdir(tmpdir)
+
+    node = {"original_file_path": "models/nonexistent.sql"}
+    result = list(_discover_sql_files(node))
+    assert result == []
+
+
+def test_discover_sql_files_with_prefix(tmpdir, monkeypatch):
+    """_discover_sql_files finds file when dbt project is in a subdirectory."""
+    monkeypatch.chdir(tmpdir)
+    sql_dir = Path(str(tmpdir)) / "dbt_project" / "models"
+    sql_dir.mkdir(parents=True)
+    (sql_dir / "orders.sql").write_text("SELECT 1")
+
+    node = {"original_file_path": "models/orders.sql"}
+    result = list(_discover_sql_files(node, prefix="dbt_project/"))
+    assert len(result) == 1
+    assert result[0] == Path("dbt_project/models/orders.sql")
+
+
+def test_discover_prop_files_direct_path(tmpdir, monkeypatch):
+    """_discover_prop_files finds file by direct path, not recursive glob."""
+    monkeypatch.chdir(tmpdir)
+    yml_dir = Path(str(tmpdir)) / "models" / "staging"
+    yml_dir.mkdir(parents=True)
+    (yml_dir / "_schema.yml").write_text("version: 2")
+
+    result = list(_discover_prop_files("models/staging/_schema.yml"))
+    assert len(result) == 1
+    assert result[0] == Path("models/staging/_schema.yml")
+
+
+def test_discover_prop_files_missing(tmpdir, monkeypatch):
+    """_discover_prop_files returns empty list for nonexistent file."""
+    monkeypatch.chdir(tmpdir)
+
+    result = list(_discover_prop_files("models/nonexistent.yml"))
+    assert result == []
 
 
 def test_extend_dbt_cmd_flags_without_project_dir():


### PR DESCRIPTION
## Summary

- Replaces `Path().glob('**/{path}')` with direct `Path(path).exists()` in `_discover_sql_files` and `_discover_prop_files`
- Supports `dbt-project-dir` monorepo case by inferring path prefix from pre-commit input paths
- Removes dead `target/` filtering that compensated for glob over-matching

## Motivation

Fixes #349

`_discover_sql_files()` and `_discover_prop_files()` perform a full recursive filesystem walk from CWD on every call, scanning `.venv/`, `target/`, and `.git/`. On a project with ~290 models and a virtual environment, this causes **578 glob calls** each scanning **32,490 entries**, totaling **200s+ of file discovery time**.

The manifest already provides exact relative paths — a direct existence check returns the same result **120x faster** (199s → 0.0s for discovery, 3:21 → 1.6s wall clock).

## Test plan

- [x] `_discover_sql_files` returns only the direct path, ignores `.venv` decoys
- [x] `_discover_sql_files` returns `[]` for missing files
- [x] `_discover_sql_files` works with `dbt-project-dir` prefix
- [x] `_discover_prop_files` same coverage
- [x] Full existing test suite passes (655 tests)