### PR TITLE
Fix/freshness null

### DIFF
--- a/dbt_checkpoint/check_source_has_freshness.py
+++ b/dbt_checkpoint/check_source_has_freshness.py
@@ -29,6 +29,17 @@ def has_freshness(
         table = schema.table_schema
         source_config = source.get("config") or {}
         table_config = table.get("config") or {}
+        table_freshness_null = (
+            ("freshness" in table and table["freshness"] is None)
+            or ("freshness" in table_config and table_config["freshness"] is None)
+        )
+        source_freshness_null = (
+            ("freshness" in source and source["freshness"] is None)
+            or ("freshness" in source_config and source_config["freshness"] is None)
+        )
+        table_has_own_freshness = "freshness" in table or "freshness" in table_config
+        if table_freshness_null or (source_freshness_null and not table_has_own_freshness):
+            continue
         merged = {
             **(source_config.get("freshness") or {}),
             **(source.get("freshness") or {}),

--- a/tests/unit/test_check_source_has_freshness.py
+++ b/tests/unit/test_check_source_has_freshness.py
@@ -203,6 +203,155 @@ sources:
         True,
         0,
     ),
+    # freshness: null at source level, table defines valid freshness — should pass
+    (
+        """
+sources:
+-   name: test
+    loaded_at_field: aa
+    freshness: null
+    tables:
+    -   name: with_description
+        freshness:
+            warn_after:
+                count: 12
+                period: hour
+            error_after:
+                count: 24
+                period: hour
+    """,
+        True,
+        True,
+        0,
+    ),
+    # freshness: null at table level, source defines valid freshness — should pass
+    (
+        """
+sources:
+-   name: test
+    loaded_at_field: aa
+    freshness:
+        warn_after:
+            count: 12
+            period: hour
+        error_after:
+            count: 24
+            period: hour
+    tables:
+    -   name: with_description
+        freshness: null
+    """,
+        True,
+        True,
+        0,
+    ),
+    # freshness: null at source level, table has no freshness key — source opts out all tables
+    (
+        """
+sources:
+-   name: test
+    loaded_at_field: aa
+    freshness: null
+    tables:
+    -   name: with_description
+    """,
+        True,
+        True,
+        0,
+    ),
+    # freshness: null at both levels — explicit opt-out, should pass
+    (
+        """
+sources:
+-   name: test
+    loaded_at_field: aa
+    freshness: null
+    tables:
+    -   name: with_description
+        freshness: null
+    """,
+        True,
+        True,
+        0,
+    ),
+    # freshness: null inside config: at source level, table config has valid freshness — should pass
+    (
+        """
+sources:
+-   name: test
+    config:
+        loaded_at_field: aa
+        freshness: null
+    tables:
+    -   name: with_description
+        config:
+            freshness:
+                warn_after:
+                    count: 12
+                    period: hour
+                error_after:
+                    count: 24
+                    period: hour
+    """,
+        True,
+        True,
+        0,
+    ),
+    # freshness: null inside config: at table level, source config has valid freshness — should pass
+    (
+        """
+sources:
+-   name: test
+    config:
+        loaded_at_field: aa
+        freshness:
+            warn_after:
+                count: 12
+                period: hour
+            error_after:
+                count: 24
+                period: hour
+    tables:
+    -   name: with_description
+        config:
+            freshness: null
+    """,
+        True,
+        True,
+        0,
+    ),
+    # freshness: null inside config: at source level, table has no freshness — source opts out
+    (
+        """
+sources:
+-   name: test
+    config:
+        loaded_at_field: aa
+        freshness: null
+    tables:
+    -   name: with_description
+    """,
+        True,
+        True,
+        0,
+    ),
+    # freshness: null inside config: at both levels — explicit opt-out, should pass
+    (
+        """
+sources:
+-   name: test
+    config:
+        loaded_at_field: aa
+        freshness: null
+    tables:
+    -   name: with_description
+        config:
+            freshness: null
+    """,
+        True,
+        True,
+        0,
+    ),
 )
 
 


### PR DESCRIPTION
## Summary

#308 actually didn't fix the issue and merely suppressed it.

 `check-source-has-freshness` now correctly treats `freshness: null` as an explicit opt-out rather than a missing configuration, matching dbt's own behaviour where setting `freshness: null` excludes a source from freshness calculations.

 ### Changes

**`check_source_has_freshness.py`**

Added an explicit null check before the merge step. The hook skips a table (no error) when:
  - The table itself has `freshness: null` (at the direct or `config:` level), or
  - The source has `freshness: null` and the table does not define its own `freshness`

This correctly mirrors dbt's priority order: table-level `freshness: null` opts that table out unconditionally; source-level `freshness: null` opts out any table that doesn't override it.

The distinction between an explicit opt-out (`freshness: null` — key present, value null) and a missing configuration (`freshness` key absent entirely) is preserved — tables with no `freshness` key still fail the check as expected.

**`tests/unit/test_check_source_has_freshness.py`**

Added 8 parametrized test cases covering `freshness: null` at:
  - Source level only (table has valid freshness) → pass
  - Table level only (source has valid freshness) → pass
  - Source level, table has no freshness key → pass (inherits opt-out)
  - Both levels → pass
  - All four above repeated for the `config:` block syntax