### PR TITLE
fix: detect missing macro argument descriptions when only YAML is passed

### DIFF
--- a/dbt_checkpoint/check_macro_arguments_have_desc.py
+++ b/dbt_checkpoint/check_macro_arguments_have_desc.py
@@ -2,6 +2,7 @@ import argparse
 import itertools
 import os
 import time
+from pathlib import Path
 from typing import Any, Dict, Optional, Sequence, Set
 
 from dbt_checkpoint.tracking import dbtCheckpointTracking
@@ -25,13 +26,31 @@ def check_argument_desc(
 ) -> Dict[str, Any]:
     status_code = 0
     ymls = get_filenames(paths, [".yml", ".yaml"])
+    sql_inputs = get_filenames(paths, [".sql"])
     sqls = get_macro_sqls(paths, manifest)
     filenames = set(sqls.keys())
+    yaml_only = not sql_inputs and bool(ymls)
+
+    # When only YAML files are passed (no SQL inputs at all), build sqls
+    # lookup from the manifest so macro names can be resolved to file paths
+    if yaml_only:
+        all_macro_sqls = {
+            key.split(".")[-1]: Path(macro["path"])
+            for key, macro in manifest.get("macros", {}).items()
+            if key.startswith("macro.") and macro.get("path")
+        }
+        sqls = all_macro_sqls
+        filenames = set(sqls.keys())
 
     # get manifest macros that pre-commit found as changed
-    macros = get_macros(manifest, filenames)
+    # skip manifest macro lookup in yaml-only mode — only validate what's in the YAML
+    macros = get_macros(manifest, filenames) if not yaml_only else iter([])
     # if user added schema but did not rerun the macro
-    schemas = get_macro_schemas(list(ymls.values()), filenames)
+    # use all_schemas=True when YAML-only so macros in the YAML are validated
+    # even if they don't appear in filenames (e.g., new macro not yet compiled)
+    schemas = get_macro_schemas(
+        list(ymls.values()), filenames, all_schemas=yaml_only
+    )
     missing: Dict[str, Set[str]] = {}
 
     for item in itertools.chain(macros, schemas):

--- a/tests/unit/test_check_macro_arguments_have_desc.py
+++ b/tests/unit/test_check_macro_arguments_have_desc.py
@@ -134,3 +134,60 @@ macros:
         ],
     )
     assert result == 0
+
+
+@pytest.mark.parametrize("extension", [("yml"), ("yaml")])
+def test_check_macro_arguments_have_desc_yml_only_missing(
+    extension, tmpdir, manifest_path_str
+):
+    """When only a YAML file is passed (no SQL), the hook should still detect
+    arguments with missing descriptions by resolving macros from the manifest."""
+    schema_yml = """
+version: 2
+macros:
+-   name: with_some_argument_description
+    arguments:
+    -   name: test1
+        description: aaa
+    -   name: test2
+    """
+    yml_file = tmpdir.join(f"schema.{extension}")
+    yml_file.write(schema_yml)
+    result = main(
+        argv=[
+            str(yml_file),
+            "--manifest",
+            manifest_path_str,
+            "--is_test",
+        ],
+    )
+    assert result == 1
+
+
+@pytest.mark.parametrize("extension", [("yml"), ("yaml")])
+def test_check_macro_arguments_have_desc_yml_only_passing(
+    extension, tmpdir, manifest_path_str
+):
+    """When only a YAML file is passed and all arguments have descriptions,
+    the hook should pass."""
+    schema_yml = """
+version: 2
+macros:
+-   name: with_some_argument_description
+    arguments:
+    -   name: test1
+        description: aaa
+    -   name: test2
+        description: bbb
+    """
+    yml_file = tmpdir.join(f"schema.{extension}")
+    yml_file.write(schema_yml)
+    result = main(
+        argv=[
+            str(yml_file),
+            "--manifest",
+            manifest_path_str,
+            "--is_test",
+        ],
+    )
+    assert result == 0


### PR DESCRIPTION
## Problem

When only a YAML properties file is passed to `check-macro-arguments-have-desc` (without the corresponding `.sql` file), the hook silently passes with exit code 0 — even when arguments have blank or missing descriptions.

This happens because:
1. `get_macro_sqls()` returns empty when no SQL files are in the input
2. `filenames` is therefore an empty set
3. `get_macro_schemas()` filters with `if macro_name in filenames` which never matches

In pre-commit workflows, it's common for only the YAML file to be modified (e.g., adding argument documentation) without touching the SQL file.

## Fix

When no SQL files are passed but YAML files are present:
1. Build the `sqls` lookup from the manifest's macro paths so error output can resolve file paths
2. Pass `all_schemas=True` to `get_macro_schemas` so macros defined in the YAML are validated regardless of the `filenames` filter

## Testing

Before fix:
```
$ check-macro-arguments-have-desc --manifest manifest.json -- macros/properties.yml
# exit 0 (silent pass)
```

After fix:
```
$ check-macro-arguments-have-desc --manifest manifest.json -- macros/properties.yml
macros/base/concept_mapper/common_mapper_fields.sql: following arguments are missing description:
- table_alias
# exit 1
```

Both SQL-only and SQL+YAML paths continue to work as before.