### PR TITLE
fix: check-model-columns-have-meta-keys ignores column meta under config

### DIFF
--- a/dbt_checkpoint/check_model_columns_have_meta_keys.py
+++ b/dbt_checkpoint/check_model_columns_have_meta_keys.py
@@ -22,6 +22,18 @@ from dbt_checkpoint.utils import red
 from dbt_checkpoint.utils import yellow
 
 
+def get_column_meta_keys(column: Dict[str, Any]) -> Set[str]:
+    """Return a column's meta keys.
+
+    Checks both the legacy top-level ``meta`` key and the ``config.meta``
+    location (the dbt >=1.10 convention: top-level ``meta`` on a column is
+    deprecated in favor of nesting it under ``config``). A column may use
+    either location, so both are checked and merged.
+    """
+    meta = {**column.get("meta", {}), **column.get("config", {}).get("meta", {})}
+    return set(meta.keys())
+
+
 def validate_meta_keys(
     meta: Sequence[str],
     meta_set: Set[str],
@@ -81,7 +93,7 @@ def check_column_has_meta_keys(
             column.get("name")
             for column in columns
             if not validate_meta_keys(
-                column.get("meta", {}).keys(),
+                get_column_meta_keys(column),
                 meta_set,
                 allow_extra_keys,
                 model_name,
@@ -99,7 +111,7 @@ def check_column_has_meta_keys(
             for column_name, column_config in model.node.get("columns", {}).items()
             if (
                 not validate_meta_keys(
-                    column_config.get("meta", {}).keys(),
+                    get_column_meta_keys(column_config),
                     meta_set,
                     allow_extra_keys,
                     model_name,

--- a/tests/unit/test_check_model_columns_have_meta_keys.py
+++ b/tests/unit/test_check_model_columns_have_meta_keys.py
@@ -252,6 +252,108 @@ models:
 
 
 @pytest.mark.parametrize("extension", [("yml"), ("yaml")])
+def test_check_model_columns_meta_keys_in_schema_under_config(
+    extension, tmpdir, manifest_path_str
+):
+    """Column meta declared under config.meta (the dbt >=1.10 convention,
+    since top-level meta on a column is deprecated) must be recognized the
+    same as the legacy top-level meta key."""
+    schema_yml = """
+version: 2
+
+models:
+-   name: in_schema_column_config_meta
+    columns:
+    -   name: test
+        config:
+            meta:
+                foo: foo
+                bar: bar
+    """
+    yml_file = tmpdir.join(f"schema.{extension}")
+    yml_file.write(schema_yml)
+    result = main(
+        argv=[
+            "in_schema_column_config_meta.sql",
+            str(yml_file),
+            "--meta-keys",
+            "foo",
+            "bar",
+            "--manifest",
+            manifest_path_str,
+        ],
+    )
+    assert result == 0
+
+
+@pytest.mark.parametrize("extension", [("yml"), ("yaml")])
+def test_check_model_columns_meta_keys_split_across_top_level_and_config(
+    extension, tmpdir, manifest_path_str
+):
+    """A column may have some meta keys at the top level and others under
+    config.meta (e.g. mid-migration); both locations are merged."""
+    schema_yml = """
+version: 2
+
+models:
+-   name: in_schema_column_mixed_meta
+    columns:
+    -   name: test
+        meta:
+            foo: foo
+        config:
+            meta:
+                bar: bar
+    """
+    yml_file = tmpdir.join(f"schema.{extension}")
+    yml_file.write(schema_yml)
+    result = main(
+        argv=[
+            "in_schema_column_mixed_meta.sql",
+            str(yml_file),
+            "--meta-keys",
+            "foo",
+            "bar",
+            "--manifest",
+            manifest_path_str,
+        ],
+    )
+    assert result == 0
+
+
+@pytest.mark.parametrize("extension", [("yml"), ("yaml")])
+def test_check_model_columns_meta_keys_missing_under_config(
+    extension, tmpdir, manifest_path_str
+):
+    """A column with an unrelated key under config (but no config.meta, and
+    no top-level meta) still correctly reports as missing."""
+    schema_yml = """
+version: 2
+
+models:
+-   name: in_schema_column_config_no_meta
+    columns:
+    -   name: test
+        config:
+            tags: ["some_tag"]
+    """
+    yml_file = tmpdir.join(f"schema.{extension}")
+    yml_file.write(schema_yml)
+    result = main(
+        argv=[
+            "in_schema_column_config_no_meta.sql",
+            str(yml_file),
+            "--meta-keys",
+            "foo",
+            "bar",
+            "--manifest",
+            manifest_path_str,
+        ],
+    )
+    assert result == 1
+
+
+@pytest.mark.parametrize("extension", [("yml"), ("yaml")])
 def test_check_model_columns_meta_keys_and_extra_keys_in_schema(
     extension, tmpdir, manifest_path_str
 ):


### PR DESCRIPTION
## Summary

`check-model-columns-have-meta-keys` only ever reads a column's legacy top-level `meta` key — it never checks `config.meta`. Since dbt-core 1.10 deprecated declaring `meta` at the top level of a column in favor of nesting it under `config` (see `PropertyMovedToConfigDeprecation`), any project that has migrated to the new format gets false "missing meta key" failures on every column, even though the value is present and correctly nested.

Confirmed this is still present on both the `v2.0.10` release and the current `main` branch.

Related to (but distinct from) #92, which was about the model-level hook inheriting `meta` from `dbt_project.yml` — this is the column-level hook, and the root cause is simpler: it just never looks in `config.meta` at all.

## Fix

Adds `get_column_meta_keys()`, which merges a column's top-level `meta` and `config.meta` (if a key is set in both, `config.meta` wins), and uses it in both the schema-yml pass and the manifest-node pass so a column can use either location.

## Test plan

- Added 3 new tests covering: meta declared only under `config`, meta split across both locations, and the negative case (no meta anywhere, still correctly fails).
- All 656 existing unit tests pass unchanged.
- `black`, `flake8`, `reorder-python-imports` all pass on the changed files.