### PR TITLE
fix: get_disabled() ignores dbt model versioning

### DIFF
--- a/dbt_checkpoint/utils.py
+++ b/dbt_checkpoint/utils.py
@@ -296,13 +296,25 @@ def get_macro_sqls(paths: Sequence[str], manifest: Dict[str, Any]) -> Dict[str, 
 def get_disabled(manifest: Dict[str, Any], include_disabled: bool = False) -> List[str]:
     output = []
     disabled = manifest.get("disabled", {})
-    for key, node in disabled.items():
+    for key, nodes in disabled.items():
         split_key = key.split(".")
-        filename = split_key[-1]
-        if split_key[0] == "model":
-            if include_disabled:
-                continue
-            output.append(filename)
+        if split_key[0] != "model":
+            continue
+        if include_disabled:
+            continue
+        # manifest["disabled"] maps a unique_id to a *list* of node dicts (a
+        # resource can be disabled/re-defined more than once, e.g. per version).
+        node_list = nodes if isinstance(nodes, list) else [nodes]
+        for node in node_list:
+            version = node.get("version") if isinstance(node, dict) else None
+            if version and split_key[-1] == f"v{version}":
+                # dbt versioned filenames can be either `model_name` or
+                # `model_name_v{version}` -- mirrors get_models() above, which
+                # already builds both candidates for enabled versioned models.
+                output.append(f"{split_key[-2]}")
+                output.append(f"{split_key[-2]}_v{version}")
+            else:
+                output.append(split_key[-1])
 
     return output
 

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -17,6 +17,7 @@ from dbt_checkpoint.utils import (
     extend_dbt_project_dir_flag,
     get_dbt_catalog,
     get_dbt_manifest,
+    get_disabled,
     get_filenames,
     get_macro_schemas,
     get_missing_file_paths,
@@ -248,6 +249,42 @@ def test_get_dbt_manifest_with_config_project_dir():
             expected_result = {"key": "value"}
             result = get_dbt_manifest(Args())
             assert result == expected_result
+
+
+def test_get_disabled_non_versioned():
+    manifest = {
+        "disabled": {
+            "model.pkg.my_model": [
+                {"name": "my_model", "resource_type": "model"}
+            ]
+        }
+    }
+    assert get_disabled(manifest) == ["my_model"]
+
+
+def test_get_disabled_non_versioned_include_disabled():
+    manifest = {
+        "disabled": {
+            "model.pkg.my_model": [
+                {"name": "my_model", "resource_type": "model"}
+            ]
+        }
+    }
+    assert get_disabled(manifest, include_disabled=True) == []
+
+
+def test_get_disabled_versioned_model():
+    # A versioned+disabled model's manifest key ends in "v{version}"
+    # (e.g. "model.pkg.my_model.v2"), not the real filename -- the disabled
+    # model's filename on disk can be either "my_model" or "my_model_v2".
+    manifest = {
+        "disabled": {
+            "model.pkg.my_model.v2": [
+                {"name": "my_model", "resource_type": "model", "version": 2}
+            ]
+        }
+    }
+    assert set(get_disabled(manifest)) == {"my_model", "my_model_v2"}
 
 
 def test_get_dbt_catalog_with_config_project_dir():


### PR DESCRIPTION
## What

`get_disabled()` (`dbt_checkpoint/utils.py`) derives a disabled model's filename by taking the last dot-segment of its manifest key. For a versioned model, dbt's manifest key looks like `model.<package>.<model_name>.v<version>`, so this resolves to `"v2"` — never the real filename. Since `"v2"` never matches an actual `.sql` filename, the disabled+versioned model is never excluded from checks that rely on `get_disabled()`, and gets checked as if it were enabled.

`get_models()` elsewhere in the same file already handles this correctly for enabled versioned models, by building filename candidates that include the version suffix (`model_name` and `model_name_v{version}`). This PR gives `get_disabled()` the same treatment.

Also fixes an unrelated latent bug: `manifest['disabled']` maps a unique_id to a **list** of node dicts (a resource can be disabled/re-defined more than once), which the previous implementation treated as a single node dict.

## Why

Affects any check that relies on `get_disabled()` to skip disabled models — in practice we hit this with `check-model-has-description` and `check-model-has-properties-file`: both false-positive ("does not have model properties defined in any .yml file") on a model that is both `enabled: false` and versioned, even when its properties/description are correctly defined via a `versions:` block in a sibling `.yml`.

There's no existing flag/workaround: `--include-disabled=True` doesn't fix the matching bug, it disables the exclusion attempt entirely (`get_disabled()` returns an empty list when `include_disabled=True`), so it makes no difference for a model that was already slipping through, and stops excluding non-versioned disabled models too.

## Repro

1. Create a versioned model (`versions:` block, dbt-core >= 1.5) with properties/description defined in the yml.
2. Set `enabled: false` on the model (or a specific version of it).
3. Run `check-model-has-properties-file` / `check-model-has-description` against it.
4. Observe: "does not have model properties defined in any .yml file" even though it does.

## Testing

Added unit tests for `get_disabled()` covering the non-versioned case (existing behavior preserved) and the versioned case (the fix). Ran the full `test_utils.py`, `test_check_model_has_description.py` and `test_check_model_has_properties_file.py` suites locally — all pass.